### PR TITLE
More bug fixes after testing on WWG - Wrike ID 442921011

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- WordpressRelatedPostsBlock now checks to make sure productQuery is defined before rendering
+
 ## [0.1.1] - 2020-01-13
 
 ### Fixed

--- a/react/components/WordpressRelatedPostsBlock.tsx
+++ b/react/components/WordpressRelatedPostsBlock.tsx
@@ -28,7 +28,7 @@ const WordpressRelatedPostsBlock: StorefrontFunctionComponent<WPRelatedPostsBloc
 }) => {
   const { loading: loadingS, data: dataS } = useQuery(Settings)
   const { loading, error, data } = useQuery(TagPosts, {
-    skip: !productQuery,
+    skip: !productQuery?.product?.productReference,
     variables: {
       // eslint-disable-next-line @typescript-eslint/camelcase
       wp_per_page: numberOfPosts,
@@ -36,7 +36,7 @@ const WordpressRelatedPostsBlock: StorefrontFunctionComponent<WPRelatedPostsBloc
     },
   })
   const handles = useCssHandles(CSS_HANDLES)
-  return (
+  return productQuery?.product?.productReference ? (
     <div className={`${handles.relatedPostsBlockContainer} pv4 pb9`}>
       {(loading || loadingS) && <Spinner />}
       {error && <Fragment />}
@@ -100,7 +100,7 @@ const WordpressRelatedPostsBlock: StorefrontFunctionComponent<WPRelatedPostsBloc
         <Fragment />
       )}
     </div>
-  )
+  ) : null
 }
 
 interface WPRelatedPostsBlockProps {


### PR DESCRIPTION
Prior version gave error on product page because WordpressRelatedPostsBlock was checking productQuery.product before productQuery existed in the page lifecycle. New version linked here: https://listrak--worldwidegolf.myvtex.com/footjoy-mens-drop-needle-12-zip-pullover-100010680/p