### PR TITLE
Insert Localiza Seminovos into wordpress integration

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -113,6 +113,13 @@
         "host": "invictastores.wpengine.com",
         "path": "/*"
       }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "blogsiteseminovos-d.azurewebsites.net",
+        "path": "/*"
+      }
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"


### PR DESCRIPTION
Insert Localiza Seminovos into wordpress integration on manifest.json

`{
      "name": "outbound-access",
      "attrs": {
        "host": "blogsiteseminovos-d.azurewebsites.net",
        "path": "/*"
      }
}
`

> Hi! I'm VTEX IO CI/CD Bot and I'll be helping you to publish your app! 🤖
> 
> Please select which version do you want to release:
> 
> * [ ]  Patch
> * [x]  Minor
> * [ ]  Major
> 
> And then you just need to merge your PR when you are ready! There is **no need** to create a release commit/tag.
> 
> * [ ]  No thanks, I would rather do it manually 😞

