### PR TITLE
Wrike 459623027: Fix variable used to find current search query on search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the way `WordpressProductSearchResult` accesses the current search query
+- Added missing `slug` field in some GraphQL queries
+
 ## [1.0.1] - 2020-01-17
 
 ### Fixed

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -33,19 +33,19 @@ const WordpressSearchResult: FunctionComponent<Props> = ({ searchQuery }) => {
   const { loading, error, data, fetchMore } = useQuery(SearchPosts, {
     skip: !searchQuery,
     variables: {
-      terms: searchQuery?.query ?? null,
+      terms: searchQuery?.data?.searchMetadata?.titleTag ?? null,
       wp_page: 1,
       wp_per_page: 10,
     },
   })
 
-  return searchQuery?.query ? (
+  return searchQuery?.data?.searchMetadata?.titleTag ? (
     <Fragment>
       <h2
         className={`${handles.listTitle} ${handles.searchListTitle} t-heading-2 tc`}
       >
         Article search results for &quot;
-        {searchQuery.query}
+        {searchQuery?.data?.searchMetadata?.titleTag}
         &quot;
       </h2>
 
@@ -68,7 +68,7 @@ const WordpressSearchResult: FunctionComponent<Props> = ({ searchQuery }) => {
                 variables: {
                   wp_page: 1,
                   wp_per_page: event.target.value,
-                  terms: searchQuery.query,
+                  terms: searchQuery.data.searchMetadata.titleTag,
                 },
                 updateQuery: (prev, { fetchMoreResult }) => {
                   if (!fetchMoreResult) return prev
@@ -84,7 +84,7 @@ const WordpressSearchResult: FunctionComponent<Props> = ({ searchQuery }) => {
                   variables: {
                     wp_page: prevPage,
                     wp_per_page: perPage,
-                    terms: searchQuery.query,
+                    terms: searchQuery.data.searchMetadata.titleTag,
                   },
                   updateQuery: (prev, { fetchMoreResult }) => {
                     if (!fetchMoreResult) return prev
@@ -100,7 +100,7 @@ const WordpressSearchResult: FunctionComponent<Props> = ({ searchQuery }) => {
                 variables: {
                   wp_page: nextPage,
                   wp_per_page: perPage,
-                  terms: searchQuery.query,
+                  terms: searchQuery.data.searchMetadata.titleTag,
                 },
                 updateQuery: (prev, { fetchMoreResult }) => {
                   if (!fetchMoreResult) return prev

--- a/react/graphql/SearchPosts.graphql
+++ b/react/graphql/SearchPosts.graphql
@@ -22,6 +22,7 @@ query SearchPosts($wp_page: Int, $wp_per_page: Int, $terms: String) {
       }
       date
       id
+      slug
     }
     total_count
   }

--- a/react/graphql/TagPosts.graphql
+++ b/react/graphql/TagPosts.graphql
@@ -25,6 +25,7 @@ query TagPosts($wp_page: Int, $wp_per_page: Int, $tag: String!) {
           }
           date
           id
+          slug
         }
         total_count
       }


### PR DESCRIPTION
Previously I was using `searchQuery.query` to access the current product search term, but this has apparently stopped working. This new version uses `searchQuery.data.searchMetadata.titleTag`, which contains the same information. 

New version linked here: https://wpseo--worldwidegolf.myvtex.com/shirts?_q=shirts&map=ft
(click on "Articles" tab)