### PR TITLE
Wrike 479421786: Simplify outbound access, update docs, clean up new component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Simplified outbound access rule to allow any host but only at the path `/wp-json/wp/v2/*`
+- Updated docs
+
+### Removed
+
+- Removed unnecessary props from `WordpressCategoryRelatedPostsBlock`
+
 ## [1.2.3] - 2020-03-18
+
+### Fixed
+
+- Interface for `WordpressCategoryRelatedPostsBlock`
 
 ## [1.2.2] - 2020-03-16
 
@@ -17,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.2.1] - 2020-03-12
 
 ### Changed
+
 - rebase local branch onto master in preparation of new release with interfaces update
 
 ## [1.2.0] - 2020-03-10

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,9 @@
 # Wordpress Integration
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ## Description
@@ -13,7 +16,7 @@ This app provides a way to bring in blog data from the Wordpress API and create 
 
 After installing this app in your account, navigate to the app's settings in your admin dashboard under **Apps** > **Wordpress Integration**.
 
-_Wordpress URL_ is required for the integration to function. This should be the domain where the Wordpress API endpoint is hosted and Wordpress is administered. Note that an outbound-access rule for the URL must also be present in this app's [manifest](/manifest.json) for the app to be able to access the data.
+_Wordpress URL_ is required for the integration to function. This should be the domain where the Wordpress API endpoint is hosted and Wordpress is administered.
 
 _Title tag for blog homepage_ will determine the title tag for the Wordpress portions of your store.
 
@@ -116,6 +119,11 @@ Once the routes are set up, you may populate each blog page with blocks. The Wor
 
 `blog-breadcrumb.wordpress-breadcrumb`: A breadcrumb component intended to be placed at the top of each blog page.
 
+`blog-search-list.wordpress-category-related-posts`: A block that can be used to display the title and body of one or more posts on a store category or department page. Use case: SEO text for your store's departments. By default, when placed on a store category or department page, the block will attempt to display a WordPress post tagged `"category-{id}"`, where `{id}` is the numeric ID of your VTEX store department. The block accepts the following optional props:
+
+- `categoryIdentifier`: String. You may manually specify the ID to be used in the WordPress tag. For example, if you set this prop to "test", the block will look for a WordPress post tagged "category-test". Default is an empty string.
+- `numberOfPosts`: Integer. If you wish to display more than a single post, set this prop to the number of your choice. Default is 1.
+
 ## CSS Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
@@ -180,7 +188,7 @@ You can check if others are passing through similar issues [here](https://github
 
 **Upcoming documentation:**
 
- - [add interface](https://github.com/vtex-apps/wordpress-integration/pull/15)
+- [add interface](https://github.com/vtex-apps/wordpress-integration/pull/15)
 
 ## Contributing
 
@@ -195,6 +203,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/manifest.json
+++ b/manifest.json
@@ -54,13 +54,6 @@
     {
       "name": "outbound-access",
       "attrs": {
-        "host": "blog.bennemann.com.br",
-        "path": "/*"
-      }
-    },
-    {
-      "name": "outbound-access",
-      "attrs": {
         "host": "{{account}}.vtexcommercestable.com.br",
         "path": "/api/dataentities/*"
       }
@@ -68,64 +61,8 @@
     {
       "name": "outbound-access",
       "attrs": {
-        "host": "demo.wp-api.org",
-        "path": "/*"
-      }
-    },
-    {
-      "name": "outbound-access",
-      "attrs": {
-        "host": "wwgolfshops.wpengine.com",
-        "path": "/*"
-      }
-    },
-    {
-      "name": "outbound-access",
-      "attrs": {
-        "host": "travel.redoxx.com",
-        "path": "/*"
-      }
-    },
-    {
-      "name": "outbound-access",
-      "attrs": {
-        "host": "lwshoesblog.wpengine.com",
-        "path": "/*"
-      }
-    },
-    {
-      "name": "outbound-access",
-      "attrs": {
-        "host": "texasboot.wpengine.com",
-        "path": "/*"
-      }
-    },
-    {
-      "name": "outbound-access",
-      "attrs": {
-        "host": "ebikeshop.wpengine.com",
-        "path": "/*"
-      }
-    },
-    {
-      "name": "outbound-access",
-      "attrs": {
-        "host": "lionspride.wpengine.com",
-        "path": "/*"
-      }
-    },
-    {
-      "name": "outbound-access",
-      "attrs": {
-        "host": "invictastores.wpengine.com",
-        "path": "/*"
-      }
-    },
-    {
-      "name": "outbound-access",
-      "attrs": {
-        "host": "blogsn.localiza.com",
-        "path": "/*"
+        "host": "*",
+        "path": "/wp-json/wp/v2/*"
       }
     }
   ],

--- a/react/components/WordpressCategoryRelatedPostsBlock.tsx
+++ b/react/components/WordpressCategoryRelatedPostsBlock.tsx
@@ -14,7 +14,7 @@ const CSS_HANDLES = [
   'categoryRelatedPostsBlockFlex',
   'categoryRelatedPostsBlockBody',
   'categoryRelatedPostsBlockMeta',
-  'categoryRelatedPostsBlockImage'
+  'categoryRelatedPostsBlockImage',
 ] as const
 
 const sanitizerConfig = {
@@ -64,17 +64,19 @@ const sanitizerConfig = {
 
 const WordpressCategoryRelatedPostsBlock: StorefrontFunctionComponent<WPCategoryRelatedPostsBlockProps> = ({
   numberOfPosts,
-  categoryIdentifier
+  categoryIdentifier,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const {
     route: { params },
   } = useRuntime()
 
-  if (categoryIdentifier == null || categoryIdentifier == "")
-  {
-        categoryIdentifier = typeof params.id != "undefined" && params.id != null && params.id != "" ? params.id : "";
-  }  
+  if (categoryIdentifier == null || categoryIdentifier == '') {
+    categoryIdentifier =
+      typeof params.id != 'undefined' && params.id != null && params.id != ''
+        ? params.id
+        : ''
+  }
 
   const { data: dataS } = useQuery(Settings)
   const { data } = useQuery(TagPosts, {
@@ -85,31 +87,38 @@ const WordpressCategoryRelatedPostsBlock: StorefrontFunctionComponent<WPCategory
       tag: 'category-' + categoryIdentifier,
     },
   })
- if (data?.wpTags?.tags[0]?.wpPosts.posts) {
-
+  if (data?.wpTags?.tags[0]?.wpPosts.posts) {
     let route = dataS?.appSettings?.blogRoute
     if (!route || route == '') route = 'blog'
 
     return (
       <div className={`${handles.categoryRelatedPostsBlockContainer} pv4 pb9`}>
-      {(data?.wpTags?.tags[0]?.wpPosts.posts.map(
-            (post:PostData,index: number)=>(
-      <div key={index} className={`${handles.categoryRelatedPostsBlockContainer} pv4 pb9`}>        
-      <Container className={`${handles.categoryRelatedPostsBlockFlex} pt6 pb8 ph3`}>
-          <h1
-            className={`${handles.categoryRelatedPostsBlockTitle} t-heading-1`}
-            dangerouslySetInnerHTML={{ __html: insane(post.title.rendered, sanitizerConfig) }}
-          />
+        {data?.wpTags?.tags[0]?.wpPosts.posts.map(
+          (post: PostData, index: number) => (
+            <div
+              key={index}
+              className={`${handles.categoryRelatedPostsBlockContainer} pv4 pb9`}
+            >
+              <Container
+                className={`${handles.categoryRelatedPostsBlockFlex} pt6 pb8 ph3`}
+              >
+                <h1
+                  className={`${handles.categoryRelatedPostsBlockTitle} t-heading-1`}
+                  dangerouslySetInnerHTML={{
+                    __html: insane(post.title.rendered, sanitizerConfig),
+                  }}
+                />
+                )
+                <div
+                  className={`${handles.categoryRelatedPostsBlockBody}`}
+                  dangerouslySetInnerHTML={{
+                    __html: insane(post.content.rendered, sanitizerConfig),
+                  }}
+                />
+              </Container>
+              ) : null}
+            </div>
           )
-          <div
-            className={`${handles.categoryRelatedPostsBlockBody}`}
-            dangerouslySetInnerHTML={{ __html: insane(post.content.rendered, sanitizerConfig) }}
-          />
-      </Container>
-      ) : null}
-      </div>
-      )
-      )
         )}
       </div>
     )
@@ -119,25 +128,13 @@ const WordpressCategoryRelatedPostsBlock: StorefrontFunctionComponent<WPCategory
 }
 
 interface WPCategoryRelatedPostsBlockProps {
-  title: string
   categoryIdentifier: string
   numberOfPosts: number
-  useTextOverlays: boolean
-  showCategories: boolean
-  showDates: boolean
-  showAuthors: boolean
-  showExcerpts: boolean
 }
 
 WordpressCategoryRelatedPostsBlock.defaultProps = {
-  title: 'Related Articles',
   categoryIdentifier: '',
   numberOfPosts: 1,
-  useTextOverlays: false,
-  showCategories: true,
-  showDates: true,
-  showAuthors: false,
-  showExcerpts: false,
 }
 
 const messages = defineMessages({
@@ -164,7 +161,7 @@ const messages = defineMessages({
   categoryIdentifierDescription: {
     defaultMessage: '',
     id: 'admin/editor.wordpressRelatedCategoryIdentifier.description',
-  }
+  },
 })
 
 WordpressCategoryRelatedPostsBlock.schema = {
@@ -184,7 +181,7 @@ WordpressCategoryRelatedPostsBlock.schema = {
       description: messages.categoryIdentifierDescription.id,
       type: 'string',
       isLayout: false,
-    }
+    },
   },
 }
 


### PR DESCRIPTION
**What problem is this solving?**

To prevent stores from having to open a PR to expand this app's outbound-access policies whenever they begin using the app, I have added outbound-access for "host": "*" but only at the standard WordPress API path "/wp-json/wp/v2/*".

Clarification: this is a TEMPORARY measure until the VTEX IO platform team is able to implement dynamic outbound access policies (or a similar solution).

Also updated docs and removed some unused props from the new WordpressCategoryRelatedPostsBlock component.

**How should this be manually tested?**

New version linked here: https://wptest--worldwidegolf.myvtex.com/insider
As you can see, WordPress data is coming through.
