### PR TITLE
Added CSS Handler teaserTitleLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New CSS handler `teaserTitleLink`
+
 ## [1.3.0] - 2020-03-19
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -180,6 +180,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `teaserTextOverlayMeta`                |
 | `teaserGradientOverlay`                |
 | `teaserTitle`                          |
+| `teaserTitleLink`                      |
 | `wordpressRelatedProducts`             |
 
 ## Troubleshooting

--- a/react/components/WordpressTeaser.tsx
+++ b/react/components/WordpressTeaser.tsx
@@ -166,9 +166,9 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
               <h3
                 className={`${handles.teaserTitle} t-heading-3 mv0 pt4 pb6 ph6`}
               >
-                <Link className={`${handles.teaserTitleLink}`} to={'/' + route + '/post/' + slug}>
+                <a className={`${handles.teaserTitleLink}`} href={'/' + route + '/post/' + slug}>
                   <span dangerouslySetInnerHTML={{ __html: sanitizedTitle }} />
-                </Link>
+                </a>
               </h3>
             </Fragment>
           )}
@@ -177,9 +177,9 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
 
       {mediaType != 'image' && (
         <h3 className={`${handles.teaserTitle} t-heading-3 mv0 pt4 pb6 ph6`}>
-          <Link className={`${handles.teaserTitleLink}`} to={'/' + route + '/post/' + slug}>
+          <a className={`${handles.teaserTitleLink}`} href={'/' + route + '/post/' + slug}>
             <span dangerouslySetInnerHTML={{ __html: sanitizedTitle }} />
-          </Link>
+          </a>
         </h3>
       )}
 

--- a/react/components/WordpressTeaser.tsx
+++ b/react/components/WordpressTeaser.tsx
@@ -44,6 +44,7 @@ const CSS_HANDLES = [
   'teaserTextOverlayMeta',
   'teaserGradientOverlay',
   'teaserTitle',
+  'teaserTitleLink',
 ] as const
 
 const WordpressTeaser: FunctionComponent<TeaserProps> = ({
@@ -165,9 +166,9 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
               <h3
                 className={`${handles.teaserTitle} t-heading-3 mv0 pt4 pb6 ph6`}
               >
-                <Link to={'/' + route + '/post/' + slug}>
+                <a className={`${handles.teaserTitleLink}`} href={'/' + route + '/post/' + slug}>
                   <span dangerouslySetInnerHTML={{ __html: sanitizedTitle }} />
-                </Link>
+                </a>
               </h3>
             </Fragment>
           )}
@@ -176,9 +177,9 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
 
       {mediaType != 'image' && (
         <h3 className={`${handles.teaserTitle} t-heading-3 mv0 pt4 pb6 ph6`}>
-          <Link to={'/' + route + '/post/' + slug}>
+          <a className={`${handles.teaserTitleLink}`} href={'/' + route + '/post/' + slug}>
             <span dangerouslySetInnerHTML={{ __html: sanitizedTitle }} />
-          </Link>
+          </a>
         </h3>
       )}
 

--- a/react/components/WordpressTeaser.tsx
+++ b/react/components/WordpressTeaser.tsx
@@ -166,9 +166,9 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
               <h3
                 className={`${handles.teaserTitle} t-heading-3 mv0 pt4 pb6 ph6`}
               >
-                <a className={`${handles.teaserTitleLink}`} href={'/' + route + '/post/' + slug}>
+                <Link className={`${handles.teaserTitleLink}`} to={'/' + route + '/post/' + slug}>
                   <span dangerouslySetInnerHTML={{ __html: sanitizedTitle }} />
-                </a>
+                </Link>
               </h3>
             </Fragment>
           )}
@@ -177,9 +177,9 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
 
       {mediaType != 'image' && (
         <h3 className={`${handles.teaserTitle} t-heading-3 mv0 pt4 pb6 ph6`}>
-          <a className={`${handles.teaserTitleLink}`} href={'/' + route + '/post/' + slug}>
+          <Link className={`${handles.teaserTitleLink}`} to={'/' + route + '/post/' + slug}>
             <span dangerouslySetInnerHTML={{ __html: sanitizedTitle }} />
-          </a>
+          </Link>
         </h3>
       )}
 


### PR DESCRIPTION
**What problem is this solving?**
Issue https://github.com/vtex-apps/wordpress-integration/issues/20

**How should this be manually tested?**
Use the selector `.teaserTitleLink` at the `wordpress-integration.css` file to change link style

**Screenshots or example usage:**