### PR TITLE
wrike 460923202 - update related category component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- fix extra parentheses problem, add extra supported class attributes on tags for WP posts of related categories
+
 ## [1.3.1] - 2020-03-31
 
 ### Added

--- a/react/components/WordpressCategoryRelatedPostsBlock.tsx
+++ b/react/components/WordpressCategoryRelatedPostsBlock.tsx
@@ -119,7 +119,7 @@ const WordpressCategoryRelatedPostsBlock: StorefrontFunctionComponent<WPCategory
                   }}
                 />
               </Container>
-              ) : null}
+              
             </div>
           )
         )}

--- a/react/components/WordpressCategoryRelatedPostsBlock.tsx
+++ b/react/components/WordpressCategoryRelatedPostsBlock.tsx
@@ -52,12 +52,15 @@ const sanitizerConfig = {
     'pre',
     'img',
     'iframe',
-    'figure',
+    'figure'
   ],
   allowedAttributes: {
-    a: ['href', 'name', 'target'],
-    img: ['src', 'alt'],
+    a: ['href', 'name', 'target', 'class'],
+    img: ['src', 'alt', 'class'],
     iframe: ['src', 'scrolling', 'frameborder', 'width', 'height', 'id'],
+    p: ['class'],
+    div: ['class'],
+    span: ['class']
   },
   allowedSchemes: ['http', 'https', 'mailto', 'tel'],
 }
@@ -108,7 +111,7 @@ const WordpressCategoryRelatedPostsBlock: StorefrontFunctionComponent<WPCategory
                     __html: insane(post.title.rendered, sanitizerConfig),
                   }}
                 />
-                )
+                
                 <div
                   className={`${handles.categoryRelatedPostsBlockBody}`}
                   dangerouslySetInnerHTML={{


### PR DESCRIPTION
fix extra parentheses problem, add extra supported class attributes on tags for WP posts of related categories

**What problem is this solving?**
fix extra parentheses problem, add extra supported class attributes on tags for WP posts of related categories

**How should this be manually tested?**

**Screenshots or example usage:**