### PR TITLE
wrike 490430334 - strip p tags from meta description, add meta images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- strip paragraph tags from wordpress meta descriptions, add support for wordpres post image meta tagging
+- Strip paragraph tags from Wordpress meta descriptions.
+
+### Added
+- Support for Wordpress post image meta tagging.
 
 ## [1.3.2] - 2020-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- strip paragraph tags from wordpress meta descriptions, add support for wordpres post image meta tagging
+
 ## [1.3.2] - 2020-04-13
 
 ### Fixed

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,6 +1,7 @@
 import { queries } from './resolvers/index'
 import { postResolvers } from './resolvers/postResolvers'
 import { titleResolvers } from './resolvers/titleResolvers'
+import {excerptResolvers} from './resolvers/excerptResolvers'
 import { categoryResolvers } from './resolvers/categoryResolvers'
 import { tagResolvers } from './resolvers/tagResolvers'
 import { Service } from '@vtex/api'
@@ -18,6 +19,9 @@ export default new Service({
       },
       WPTitle: {
         ...titleResolvers,
+      },
+      WPExcerpt: {
+        ...excerptResolvers,
       },
       WPCategory: {
         ...categoryResolvers,

--- a/node/resolvers/excerptResolvers.ts
+++ b/node/resolvers/excerptResolvers.ts
@@ -1,0 +1,7 @@
+import he = require('he')
+
+export const excerptResolvers = {
+  rendered: async ({ rendered }: { rendered: string }, _: any, __: any) => {
+    return he.decode(rendered)
+  },
+}

--- a/react/components/WordpressPost.tsx
+++ b/react/components/WordpressPost.tsx
@@ -132,7 +132,11 @@ const WordpressPost: FunctionComponent = props => {
               ? title.rendered + ' | ' + dataS.appSettings.titleTag
               : title.rendered}
           </title>
-          <meta name="description" content={excerpt.rendered} />
+          {featured_media?.media_type == "image" && featured_media?.source_url ? 
+              <meta property="og:image" content={featured_media?.source_url}/> : 
+              ""
+          }
+          <meta name="description" content={excerpt.rendered.replace(/<p>/gi,"").replace(/<\/p>/gi,"").trim()} />
         </Helmet>
         <div className={`${handles.postContainer} ph3`}>
           <h1

--- a/react/components/WordpressPost.tsx
+++ b/react/components/WordpressPost.tsx
@@ -136,7 +136,7 @@ const WordpressPost: FunctionComponent = props => {
               <meta property="og:image" content={featured_media?.source_url}/> : 
               ""
           }
-          <meta name="description" content={excerpt.rendered.replace(/<p>/gi,"").replace(/<\/p>/gi,"").trim()} />
+          <meta name="description" content={excerpt?.rendered?.replace(/<p>/gi,"").replace(/<\/p>/gi,"").trim()} />
         </Helmet>
         <div className={`${handles.postContainer} ph3`}>
           <h1


### PR DESCRIPTION
strip p tags from meta description, add meta images

**What problem is this solving?**

implement these meta images and meta descriptions without <p> tags to help us improve SEO

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

view-source:https://wordpressmetapages--redoxx.myvtex.com/travel/post/personal-renaissance-exploring-maestros-italian-glass-blowing-murano

shows new image tag and altered description tag: 

```<meta data-react-helmet="true" property="og:image" content="https://travel.redoxx.com/wp-content/uploads/2017/01/murano-island.jpg"/><meta data-react-helmet="true" name="description" content="In this episode of CEO Jim&amp;#8217;s OxxTales, Red Oxx CEO Markel returns to his place of birth and learns the art of glass blowing from the masters."/>```
