### PR TITLE
Wrike 483336894: Add error handling for featured media resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add error handling for featured media resolver failures
+
 ## [1.3.3] - 2020-04-16
 
 ### Fixed
@@ -13,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Strip paragraph tags from Wordpress meta descriptions.
 
 ### Added
+
 - Support for Wordpress post image meta tagging.
 
 ## [1.3.2] - 2020-04-13
@@ -26,7 +31,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - New CSS handler `teaserTitleLink`.
-
 
 ## [1.3.0] - 2020-03-19
 

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,7 +1,7 @@
 import { queries } from './resolvers/index'
 import { postResolvers } from './resolvers/postResolvers'
 import { titleResolvers } from './resolvers/titleResolvers'
-import {excerptResolvers} from './resolvers/excerptResolvers'
+import { excerptResolvers } from './resolvers/excerptResolvers'
 import { categoryResolvers } from './resolvers/categoryResolvers'
 import { tagResolvers } from './resolvers/tagResolvers'
 import { Service } from '@vtex/api'

--- a/node/resolvers/postResolvers.ts
+++ b/node/resolvers/postResolvers.ts
@@ -4,7 +4,12 @@ export const postResolvers = {
     const {
       clients: { wordpressProxy },
     } = ctx
-    return wordpressProxy.getUser(author)
+    try {
+      return await wordpressProxy.getUser(author)
+    } catch (e) {
+      console.error(e)
+    }
+    return null
   },
   categories: async (
     { categories }: { categories: [number] },
@@ -31,9 +36,12 @@ export const postResolvers = {
       clients: { wordpressProxy },
     } = ctx
     if (featured_media > 0) {
-      return wordpressProxy.getMediaSingle(featured_media)
-    } else {
-      return null
+      try {
+        return await wordpressProxy.getMediaSingle(featured_media)
+      } catch (e) {
+        console.error(e)
+      }
     }
+    return null
   },
 }


### PR DESCRIPTION
**What problem is this solving?**

Each WordPress post typically has a `featured_media` (primary image) attached to it. This is represented in the API data by an ID number. When our app receives the ID, a resolver hits a second API endpoint to load the details for that image. In some situations this results in a 401 error - perhaps the image is not published, or some other error prevents us from accessing it. This PR adds handling around these 401 errors. 

**How should this be manually tested?**

Compare https://eriksbikeshop.myvtex.com/blog/ and https://wordpress--eriksbikeshop.myvtex.com/blog/
The same data results in a 401 error on the first link, and simply a post with no image in the second.
