### PR TITLE
Bugfix/metatag adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+
+- Removing html tags from the metatag description
+
 ## [1.4.0] - 2020-04-28
 
 ### Added

--- a/react/components/WordpressPost.tsx
+++ b/react/components/WordpressPost.tsx
@@ -136,7 +136,8 @@ const WordpressPost: FunctionComponent = props => {
               <meta property="og:image" content={featured_media?.source_url}/> : 
               ""
           }
-          <meta name="description" content={excerpt?.rendered?.replace(/<p>/gi,"").replace(/<\/p>/gi,"").trim()} />
+          <meta name="description" content={excerpt?.rendered?.replace(/(<([^>]+)>)/ig, "").trim()} />
+
         </Helmet>
         <div className={`${handles.postContainer} ph3`}>
           <h1


### PR DESCRIPTION
**What problem is this solving?**
Not only tag P is being shown on the metatag description, I'm now removing all the HTML tags from it
<!--- What is the motivation and context for this change? -->
Metatags shouldn't have html on their contents

**How should this be manually tested?**
Link the app, and navigate to a POST that would have html on its metatag description, check the sourcecode

[Example](https://www.redoxx.com/travel/post/a-tail-of-two-leashes-a-story-of-gratitude-for-furry-friends)

**Screenshots or example usage:**