### PR TITLE
Fix Wordpress page GraphQL errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- WordPress page GraphQL queries now work correctly
+
 ## [2.1.3] - 2020-10-20
+
+### Changed
+
+- Update ES messages
 
 ## [2.1.2] - 2020-10-20
 
+### Changed
+
+- Update PT messages
+
 ## [2.1.1] - 2020-10-14
 
+### Changed
+
+- Update docs
+
 ## [2.1.0] - 2020-10-02
+
+### Added
+
+- `blog-post-navigation.wordpress` and `blog-post-container.wordpress` blocks
 
 ## [2.0.3] - 2020-08-26
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -229,9 +229,9 @@ type WPPage {
   parent: Int
   title: WPTitle
   content: WPContent
-  author: WPUser
+  author(customDomain: String): WPUser
   excerpt: WPExcerpt
-  featured_media: WPMedia
+  featured_media(customDomain: String): WPMedia
   comment_status: WPOpenClosed
   ping_status: WPOpenClosed
   menu_order: Int

--- a/messages/en.json
+++ b/messages/en.json
@@ -31,6 +31,8 @@
   "admin/editor.wordpressAuthors.description": "Show author of each post",
   "admin/editor.wordpressExcerpts.title": "Show Excerpts",
   "admin/editor.wordpressExcerpts.description": "Show excerpt for each post",
+  "admin/editor.absoluteLinks.title": "Use Absolute Links",
+  "admin/editor.absoluteLinks.description": "Link to external WordPress URL instead of relative store URL",
   "admin/editor.wordpressCategories.title": "Show Categories",
   "admin/editor.wordpressCategories.description": "Show first category of each post",
   "admin/editor.wordpressLatestPosts.title": "Wordpress Latest Posts Block",

--- a/messages/es.json
+++ b/messages/es.json
@@ -31,6 +31,8 @@
   "admin/editor.wordpressAuthors.description": "Mostrar el autor de cada post",
   "admin/editor.wordpressExcerpts.title": "Mostrar Extractos",
   "admin/editor.wordpressExcerpts.description": "Mostrar extracto de cada post",
+  "admin/editor.absoluteLinks.title": "Use Absolute Links",
+  "admin/editor.absoluteLinks.description": "Link to external WordPress URL instead of relative store URL",
   "admin/editor.wordpressCategories.title": "Mostrar Categorías",
   "admin/editor.wordpressCategories.description": "Mostrar la primera categoría de cada post",
   "admin/editor.wordpressLatestPosts.title": "Bloque de los Últimos Posts de WordPress",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -31,6 +31,8 @@
   "admin/editor.wordpressAuthors.description": "Mostrar o autor de cada post",
   "admin/editor.wordpressExcerpts.title": "Mostrar Trechos",
   "admin/editor.wordpressExcerpts.description": "Mostrar um trecho de cada post",
+  "admin/editor.absoluteLinks.title": "Use Absolute Links",
+  "admin/editor.absoluteLinks.description": "Link to external WordPress URL instead of relative store URL",
   "admin/editor.wordpressCategories.title": "Mostrar Categorias",
   "admin/editor.wordpressCategories.description": "Mostrar a primeira categoria de cada post",
   "admin/editor.wordpressLatestPosts.title": "Bloco de Posts mais Recentes do Wordpress",

--- a/node/package.json
+++ b/node/package.json
@@ -11,7 +11,7 @@
     "graphql": "^14.2.1",
     "he": "^1.2.0",
     "prettier": "^1.17.1",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "devDependencies": {
     "@types/he": "^1.1.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2416,10 +2416,10 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/react/components/WordpressPage.tsx
+++ b/react/components/WordpressPage.tsx
@@ -150,7 +150,7 @@ const WordpressPageInner: FunctionComponent<{ pageData: any }> = props => {
           dangerouslySetInnerHTML={{ __html: titleHtml }}
         />
         <p className={`${handles.postMeta} t-small mw9 c-muted-1`}>
-          <span>Posted {formattedDate} in </span>
+          <span>Posted {formattedDate} </span>
           {author && <span> by {author.name}</span>}
         </p>
         {featured_media && featured_media.media_type === 'image' && (

--- a/react/package.json
+++ b/react/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^16.8.5",
     "react-helmet": "^5.2.0",
     "react-intl": "^2.9.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "devDependencies": {
     "@types/graphql": "^14.5.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -493,10 +493,10 @@ tslib@^1.10.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 "vtex.blog-interfaces@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.blog-interfaces@0.1.0/public/@types/vtex.blog-interfaces":
   version "0.1.0"


### PR DESCRIPTION
**What problem is this solving?**

After receiving a request for help configuring the WordPress app for the `arcaplanetqa` account, I discovered that the GraphQL query for WordPress "pages" (not to be confused with posts) was throwing an error. This PR corrects this and also fixes a few miscellaneous bugs such as missing intl messages and empty changelog entries.

**How should this be manually tested?**

New version linked here: https://arthur--arcaplanetqa.myvtex.com/blog/page/arca-coupon