### PR TITLE
Added CSS Handle for teaser body text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.2] - 2020-11-17
+
+### Changed
+
+- Add CSS handle for post body in teasers
+- Update docs
+
 ## [2.2.1] - 2020-11-09
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -354,6 +354,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `teaserDate`                           |
 | `teaserGradientOverlay`                |
 | `teaserImage`                          |
+| `teaserBody`                           |
 | `teaserSeparator`                      |
 | `teaserTextOverlay`                    |
 | `teaserTextOverlayTitle`               |

--- a/react/components/WordpressTeaser.tsx
+++ b/react/components/WordpressTeaser.tsx
@@ -42,6 +42,7 @@ const CSS_HANDLES = [
   'teaserGradientOverlay',
   'teaserTitle',
   'teaserTitleLink',
+  'teaserBody',
   'teaserCategoryLink',
   'teaserAuthor',
   'teaserDate',
@@ -277,7 +278,7 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
 
       {showExcerpt && (
         <div
-          className="ph6 pb6"
+          className={`${handles.teaserBody} ph6 pb6`}
           dangerouslySetInnerHTML={{ __html: sanitizedExcerpt }}
         />
       )}


### PR DESCRIPTION
**What problem is this solving?**

This adds a CSS handle on the div that wraps the paragraph with the excerpts.   It is needed to customize the text inside.

**How should this be manually tested?**

New version linked on https://razvan2--vetrob2c.myvtex.com/ (which is a dev environment) OR can be seen here
![image](https://user-images.githubusercontent.com/71461884/99408678-27861b00-28f9-11eb-8c1f-f22d4f5577c4.png)
