### PR TITLE
Add CSS handles to post and page body HTML, add support for route ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.2.2] - 2020-11-18
+### Changed
 
-## [2.2.2] - 2020-11-17
+- Prefix CSS classes in WordPress post and page body HTML to enable them as CSS handles
+- Identify pages on Site Editor with `_id` on runtime params and links
+- Update docs
+
+## [2.2.2] - 2020-11-18
 
 ### Changed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,17 +46,17 @@ It is time to create the store pages that will host the blog content. Before per
 	"path": "/blog"
 },
 "store.blog-category": {
-	"path": "/blog/category/:categoryslug"
+	"path": "/blog/category/:categoryslug_id"
 },
 "store.blog-post": {
-	"path": "/blog/post/:slug"
+	"path": "/blog/post/:slug_id"
 },
 "store.blog-search-result": {
-	"path": "/blog/search/:term"
+	"path": "/blog/search/:term_id"
 }
 ```
 
-:information_source: _You may change `blog` in each route to another string of your choosing._
+:information*source: \_You may change `blog` in each route to another string of your choosing.*
 
 | Blog page                  | Description                                                                                                                             |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
@@ -68,7 +68,7 @@ It is time to create the store pages that will host the blog content. Before per
 If you wish to display WordPress **pages** on your store site in addition to **posts**, you can add a route like the one shown below:
 
 ```json
-"store.blog-home#page": {
+"store.custom#blog-page": {
 	"path": "/blog/page/:slug"
 }
 ```
@@ -80,10 +80,10 @@ In addition to that, you can optionally add `:page` parameters for URL-controlle
 	"path": "/blog(/page/:page)"
 },
 "store.blog-category": {
-	"path": "/blog/category/:categoryslug(/page/:page)"
+	"path": "/blog/category/:categoryslug_id(/page/:page)"
 },
 "store.blog-search-result": {
-	"path": "/blog/search/:term(/page/:page)"
+	"path": "/blog/search/:term_id(/page/:page)"
 },
 ```
 
@@ -187,7 +187,7 @@ Starting with version 1.6.0 of this app, blog content from **multiple WordPress 
 
 To accomplish this, a `customdomainslug` parameter must be added to your blog routes, and your WordPress blocks must be updated with various props.
 
-:information_source: _This configuration is not required if you only wish to display blog content from a single WordPress domain._
+:information*source: \_This configuration is not required if you only wish to display blog content from a single WordPress domain.*
 
 #### Step 1 - Adding the `customdomainslug` parameter
 
@@ -200,16 +200,16 @@ It is time to create the store pages that will host the blog content. Before per
 	"path": "/blog"
 },
 "store.blog-category": {
-	"path": "/:customdomainslug/category/:categoryslug"
+	"path": "/:customdomainslug/category/:categoryslug_id"
 },
 "store.blog-post": {
-	"path": "/:customdomainslug/post/:slug"
+	"path": "/:customdomainslug/post/:slug_id"
 },
 "store.blog-search-result": {
-	"path": "/:customdomainslug/search/:term"
+	"path": "/:customdomainslug/search/:term_id"
 },
-"store.blog-home#page": {
-	"path": "/:customdomainslug/page/:slug"
+"store.custom#blog-page": {
+	"path": "/:customdomainslug/page/:slug_id"
 }
 ```
 
@@ -239,7 +239,7 @@ For example, if you wanted URLs with the slug `blog` to load content from `http:
 }
 ```
 
-:information_source: _Make sure to follow the format of the example value, including the brackets and escaped double quotes._
+:information*source: \_Make sure to follow the format of the example value, including the brackets and escaped double quotes.*
 
 Blocks that do not use URL params should be given a different set of props, namely `customDomainSlug` and `customDomain`. These blocks are:
 
@@ -293,7 +293,7 @@ Continuing the example from above, any block that shows content from the "defaul
   },
 ```
 
-:information_source: _Make sure to follow the format of the example value, including the brackets and escaped double quotes._
+:information*source: \_Make sure to follow the format of the example value, including the brackets and escaped double quotes.*
 
 ## Customization
 

--- a/react/components/WordpressBreadcrumb.tsx
+++ b/react/components/WordpressBreadcrumb.tsx
@@ -85,6 +85,7 @@ const WordpressSinglePostBreadcrumb: FunctionComponent<SinglePostProps> = ({
           page="store.blog-category"
           params={{
             categoryslug: data.wpPosts.posts[0].categories[0].slug,
+            categoryslug_id: data.wpPosts.posts[0].categories[0].slug,
             customdomainslug: customDomainSlug,
           }}
           className={`${handles.breadcrumbLink}`}
@@ -119,7 +120,7 @@ const WordpressBreadcrumb: StorefrontFunctionComponent<Props> = ({
       : undefined
 
   // if we're on a category page with a slug
-  if (params?.categoryslug) {
+  if (params?.categoryslug || params?.categoryslug_id) {
     return (
       <WordpressCategoryBreadcrumb
         categorySlug={params.categoryslug}
@@ -129,7 +130,7 @@ const WordpressBreadcrumb: StorefrontFunctionComponent<Props> = ({
   }
 
   // if we're on an article search page
-  if (params?.term) {
+  if (params?.term || params?.term_id) {
     return (
       <Container
         className={`${handles.breadcrumbContainer} pt2 pb8`}
@@ -146,17 +147,17 @@ const WordpressBreadcrumb: StorefrontFunctionComponent<Props> = ({
         </Link>
         <span className={`${handles.breadcrumbSeparator}`}>&nbsp;/&nbsp;</span>
         <span className={`${handles.breadcrumbCurrentPage}`}>
-          Search results for &quot;{params.term}&quot;
+          Search results for &quot;{params.term || params.term_id}&quot;
         </span>
       </Container>
     )
   }
 
   // if we're viewing a single blog post with a slug
-  if (params?.slug) {
+  if (params?.slug || params?.slug_id) {
     return (
       <WordpressSinglePostBreadcrumb
-        slug={params.slug}
+        slug={params.slug || params.slug_id}
         customDomain={customDomain}
         customDomainSlug={params.customdomainslug}
       />

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -55,7 +55,9 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
   const initialPage = params.page ?? query?.page ?? '1'
   const [page, setPage] = useState(parseInt(initialPage, 10))
   const [perPage, setPerPage] = useState(10)
-  const categoryVariable = { categorySlug: params.categoryslug }
+  const categoryVariable = {
+    categorySlug: params.categoryslug || params.categoryslug_id,
+  }
   const handles = useCssHandles(CSS_HANDLES)
   const { loading: loadingS, data: dataS } = useQuery(Settings)
   const { loading, error, data, fetchMore } = useQuery(CategoryPostsBySlug, {

--- a/react/components/WordpressCategoryBlock.tsx
+++ b/react/components/WordpressCategoryBlock.tsx
@@ -104,6 +104,7 @@ const WordpressCategoryBlock: StorefrontFunctionComponent<WPCategoryBlockProps> 
               page="store.blog-category"
               params={{
                 categoryslug: data?.wpCategory?.slug,
+                categoryslug_id: data?.wpCategory?.slug,
                 customdomainslug: customDomainSlug,
               }}
               className={`${handles.categoryBlockLink}`}

--- a/react/components/WordpressPage.tsx
+++ b/react/components/WordpressPage.tsx
@@ -17,6 +17,7 @@ interface PageProps {
   customDomains: string
 }
 
+const allowClass = ['class']
 const sanitizerConfig = {
   allowedTags: [
     'h1',
@@ -55,9 +56,48 @@ const sanitizerConfig = {
     'figure',
   ],
   allowedAttributes: {
-    a: ['href', 'name', 'target'],
-    img: ['src', 'alt'],
-    iframe: ['src', 'scrolling', 'frameborder', 'width', 'height', 'id'],
+    h1: allowClass,
+    h2: allowClass,
+    h3: allowClass,
+    h4: allowClass,
+    h5: allowClass,
+    h6: allowClass,
+    blockquote: allowClass,
+    p: allowClass,
+    a: ['class', 'href', 'name', 'target', 'rel'],
+    ul: allowClass,
+    ol: allowClass,
+    nl: allowClass,
+    li: allowClass,
+    b: allowClass,
+    i: allowClass,
+    strong: allowClass,
+    section: allowClass,
+    em: allowClass,
+    strike: allowClass,
+    code: allowClass,
+    hr: allowClass,
+    br: allowClass,
+    div: allowClass,
+    table: allowClass,
+    thead: allowClass,
+    caption: allowClass,
+    tbody: allowClass,
+    tr: allowClass,
+    th: allowClass,
+    td: allowClass,
+    pre: allowClass,
+    img: ['class', 'src', 'alt'],
+    iframe: [
+      'class',
+      'src',
+      'scrolling',
+      'frameborder',
+      'width',
+      'height',
+      'id',
+    ],
+    figure: allowClass,
   },
   allowedSchemes: ['http', 'https', 'mailto', 'tel'],
 }
@@ -67,6 +107,8 @@ const sanitizerConfigStripAll = {
   allowedTags: false,
   allowedSchemes: [],
 }
+
+const classRegex = /(class=")([^"]*)(")/g
 
 const CSS_HANDLES = [
   'postFlex',
@@ -112,7 +154,16 @@ const WordpressPageInner: FunctionComponent<{ pageData: any }> = props => {
       : null
   }, [featured_media?.caption?.rendered, sanitizerConfigStripAll])
   const bodyHtml = useMemo(() => {
-    return insane(content.rendered, sanitizerConfig)
+    let html = insane(content.rendered, sanitizerConfig)
+    // eslint-disable-next-line max-params
+    html = html.replace(classRegex, (_, $1, $2, $3) => {
+      const classArray = $2.split(' ')
+      const newClasses = classArray.map(
+        (item: string) => `vtex-wordpress-integration-2-x-${item}`
+      )
+      return `${$1}${newClasses.join(' ')}${$3}`
+    })
+    return html
   }, [content.rendered, sanitizerConfig])
 
   if (loadingS) {

--- a/react/components/WordpressSearchBlock.tsx
+++ b/react/components/WordpressSearchBlock.tsx
@@ -21,7 +21,11 @@ const WordpressSearchBlock: StorefrontFunctionComponent<WordpressSearchProps> = 
     setValue('')
     navigate({
       page: 'store.blog-search-result',
-      params: { term: search, customdomainslug: customDomainSlug },
+      params: {
+        term: search,
+        term_id: search,
+        customdomainslug: customDomainSlug,
+      },
     })
   }
 

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -58,14 +58,16 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
   const { loading, error, data, fetchMore } = useQuery(SearchPosts, {
     skip: !params,
     variables: {
-      terms: params.term,
+      terms: params.term || params.term_id,
       wp_page: 1,
       wp_per_page: 10,
       customDomain,
     },
   })
 
-  if (!params || !params.term) return null
+  if (!params?.term && !params?.term_id) return null
+
+  const term = params.term || params.term_id
 
   const paginationComponent = (
     <Pagination
@@ -92,7 +94,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
           variables: {
             wp_page: 1,
             wp_per_page: event.target.value,
-            terms: params.term,
+            terms: term,
             customDomain,
           },
           updateQuery: (prev, { fetchMoreResult }) => {
@@ -119,7 +121,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
           variables: {
             wp_page: prevPage,
             wp_per_page: perPage,
-            terms: params.term,
+            terms: term,
             customDomain,
           },
           updateQuery: (prev, { fetchMoreResult }) => {
@@ -145,7 +147,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
           variables: {
             wp_page: nextPage,
             wp_per_page: perPage,
-            terms: params.term,
+            terms: term,
             customDomain,
           },
           updateQuery: (prev, { fetchMoreResult }) => {
@@ -161,16 +163,16 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
       <Helmet>
         <title>
           {dataS?.appSettings?.titleTag
-            ? `Article search results for ${decodeURIComponent(
-                params.term
-              )} | ${dataS.appSettings.titleTag}`
-            : `Article search results for ${decodeURIComponent(params.term)}`}
+            ? `Article search results for ${decodeURIComponent(term)} | ${
+                dataS.appSettings.titleTag
+              }`
+            : `Article search results for ${decodeURIComponent(term)}`}
         </title>
       </Helmet>
       <h2
         className={`${handles.listTitle} ${handles.searchListTitle} t-heading-2 tc`}
       >
-        Article search results for &quot;{decodeURIComponent(params.term)}
+        Article search results for &quot;{decodeURIComponent(term)}
         &quot;
       </h2>
 

--- a/react/components/WordpressSearchResultBlock.tsx
+++ b/react/components/WordpressSearchResultBlock.tsx
@@ -86,6 +86,7 @@ const WordpressSearchResultBlock: StorefrontFunctionComponent<WPSearchResultBloc
             page="store.blog-search-result"
             params={{
               term: searchQuery.productSearch.titleTag,
+              term_id: searchQuery.productSearch.titleTag,
               page: '1',
               customdomainslug: customDomainSlug,
             }}

--- a/react/components/WordpressTeaser.tsx
+++ b/react/components/WordpressTeaser.tsx
@@ -90,6 +90,7 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
                   page="store.blog-category"
                   params={{
                     categoryslug: categorySlug,
+                    categoryslug_id: categorySlug,
                     customdomainslug: customDomainSlug,
                   }}
                   className={`${handles.teaserCategoryLink}`}
@@ -148,7 +149,11 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
                     ) : (
                       <Link
                         page="store.blog-post"
-                        params={{ slug, customdomainslug: customDomainSlug }}
+                        params={{
+                          slug,
+                          slug_id: slug,
+                          customdomainslug: customDomainSlug,
+                        }}
                         className="white no-underline"
                       >
                         {title}
@@ -165,6 +170,7 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
                             page="store.blog-category"
                             params={{
                               categoryslug: categorySlug,
+                              categoryslug_id: categorySlug,
                               customdomainslug: customDomainSlug,
                             }}
                             className={`${handles.teaserCategoryLink} white`}
@@ -214,7 +220,11 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
               ) : (
                 <Link
                   page="store.blog-post"
-                  params={{ slug, customdomainslug: customDomainSlug }}
+                  params={{
+                    slug,
+                    slug_id: slug,
+                    customdomainslug: customDomainSlug,
+                  }}
                   className="tc-m db"
                 >
                   <img
@@ -241,7 +251,11 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
                   <Link
                     className={`${handles.teaserTitleLink}`}
                     page="store.blog-post"
-                    params={{ slug, customdomainslug: customDomainSlug }}
+                    params={{
+                      slug,
+                      slug_id: slug,
+                      customdomainslug: customDomainSlug,
+                    }}
                   >
                     <span
                       dangerouslySetInnerHTML={{ __html: sanitizedTitle }}
@@ -268,7 +282,11 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
             <Link
               className={`${handles.teaserTitleLink}`}
               page="store.blog-post"
-              params={{ slug, customdomainslug: customDomainSlug }}
+              params={{
+                slug,
+                slug_id: slug,
+                customdomainslug: customDomainSlug,
+              }}
             >
               <span dangerouslySetInnerHTML={{ __html: sanitizedTitle }} />
             </Link>


### PR DESCRIPTION
**What problem is this solving?**

This PR allows the contents of a WordPress post or page to be styled through the store-theme, by adding CSS handle prefixes to the CSS classes inside the rendered HTML that the app receives from the WP API. 

This PR also incorporates the route improvements that were previously added to the 1.x version by this PR: https://github.com/vtex-apps/wordpress-integration/pull/49

**How should this be manually tested?**

New version linked here: https://arthur--arcaplanetqa.myvtex.com/blog/post/8