### PR TITLE
1.x: Fix conditional for search results component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Params conditional on search results component
+
 ## [1.6.2] - 2020-11-05
 
 ### Added
 
 - Identify pages on Site Editor with `_id` on runtime params and links
-  
+
 ## [1.6.1] - 2020-06-12
 
 ### Changed

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -65,7 +65,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
     },
   })
 
-  if (!params?.term || !params?.term_id) return null
+  if (!params?.term && !params?.term_id) return null
 
   const term = params.term || params.term_id
   const paginationComponent = (


### PR DESCRIPTION
**What problem is this solving?**
WordPress 1.x search results page was showing no results: https://eriksbikeshop.myvtex.com/blog/search/apparel

This was because there was a conditional that said if either `params.term` or `params.term_id` were falsy, the component would render `null`. New version changes this so that BOTH must be falsy in order to render `null`. 

New version linked here: https://arthur--eriksbikeshop.myvtex.com/blog/search/apparel

This bug has already been fixed in the 2.x version.