### PR TITLE
Use client locale for blog date display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Use client locale for blog date display
+
 ## [2.4.0] - 2021-01-22
 
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,6 @@
     "vtex.shelf": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shelf@1.44.2/public/_types/react",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.110.0/public/@types/vtex.store",
     "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.140.0/public/@types/vtex.store-components",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.0/public/@types/vtex.styleguide",
-    "vtex.wordpress-integration": "https://arthur--arteni.myvtex.com/_v/private/typings/linked/v1/vtex.wordpress-integration@2.3.1+build1611344561/public/@types/vtex.wordpress-integration"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.0/public/@types/vtex.styleguide"
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1550,10 +1550,6 @@ vary@^1.1.2:
   version "9.135.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.0/public/@types/vtex.styleguide#3884521971a1c0f9b3773231b135e1e4abf9020f"
 
-"vtex.wordpress-integration@https://arthur--arteni.myvtex.com/_v/private/typings/linked/v1/vtex.wordpress-integration@2.3.1+build1611344561/public/@types/vtex.wordpress-integration":
-  version "2.3.1"
-  resolved "https://arthur--arteni.myvtex.com/_v/private/typings/linked/v1/vtex.wordpress-integration@2.3.1+build1611344561/public/@types/vtex.wordpress-integration#0afb3c1ed4e0f02aa11d0fea69f13952789616e0"
-
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"

--- a/react/components/WordpressPage.tsx
+++ b/react/components/WordpressPage.tsx
@@ -121,6 +121,9 @@ const CSS_HANDLES = [
 
 const WordpressPageInner: FunctionComponent<{ pageData: any }> = props => {
   const handles = useCssHandles(CSS_HANDLES)
+  const {
+    culture: { locale },
+  } = useRuntime()
   const { loading: loadingS, data: dataS } = useQuery(Settings)
 
   if (!props.pageData) {
@@ -142,7 +145,7 @@ const WordpressPageInner: FunctionComponent<{ pageData: any }> = props => {
 
   const dateObj = new Date(date)
   const dateOptions = { year: 'numeric', month: 'long', day: 'numeric' }
-  const formattedDate = dateObj.toLocaleDateString('en-US', dateOptions)
+  const formattedDate = dateObj.toLocaleDateString(locale, dateOptions)
 
   const titleHtml = useMemo(() => {
     return insane(title.rendered, sanitizerConfig)

--- a/react/components/WordpressPost.tsx
+++ b/react/components/WordpressPost.tsx
@@ -125,6 +125,10 @@ const WordpressPostInner: FunctionComponent<{
   customDomainSlug?: string
 }> = props => {
   const handles = useCssHandles(CSS_HANDLES)
+  const {
+    culture: { locale },
+  } = useRuntime()
+
   const { loading: loadingS, data: dataS } = useQuery(Settings)
 
   if (!props.postData) {
@@ -148,7 +152,7 @@ const WordpressPostInner: FunctionComponent<{
 
   const dateObj = new Date(date)
   const dateOptions = { year: 'numeric', month: 'long', day: 'numeric' }
-  const formattedDate = dateObj.toLocaleDateString('en-US', dateOptions)
+  const formattedDate = dateObj.toLocaleDateString(locale, dateOptions)
 
   const productIds = tags
     .filter((tag: WPTag) => tag.name && tag.name.includes('prod-'))

--- a/react/components/WordpressTeaser.tsx
+++ b/react/components/WordpressTeaser.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, Fragment, useMemo } from 'react'
 import { Card } from 'vtex.styleguide'
-import { Link } from 'vtex.render-runtime'
+import { Link, useRuntime } from 'vtex.render-runtime'
 import insane from 'insane'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -71,9 +71,13 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
   useTextOverlay,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
+  const {
+    culture: { locale },
+  } = useRuntime()
+
   const dateObj = new Date(date)
   const dateOptions = { year: 'numeric', month: 'long', day: 'numeric' }
-  const formattedDate = dateObj.toLocaleDateString('en-US', dateOptions)
+  const formattedDate = dateObj.toLocaleDateString(locale, dateOptions)
   const sanitizedTitle = useMemo(() => {
     return insane(title, sanitizerConfigStripAll)
   }, [title, sanitizerConfigStripAll])


### PR DESCRIPTION
**What problem is this solving?**

Display the blog publish dates in the browsers locale
<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**
[Workspace](https://sdb--arteni.myvtex.com/blog)


**Screenshots or example usage:**

![Screenshot from 2021-01-26 15-44-11](https://user-images.githubusercontent.com/22715037/105905762-d5483100-5ff0-11eb-9302-ccb6206f7740.png)


![Screenshot from 2021-01-26 15-50-16](https://user-images.githubusercontent.com/22715037/105905771-d7aa8b00-5ff0-11eb-9610-44c7da9280d8.png)
