### PR TITLE
Added CSS Handle for image container (on Link)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- CSS handle for Wordpress Teaser image container
+
 ## [2.4.2] - 2021-02-02
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -355,6 +355,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `teaserDate`                           |
 | `teaserGradientOverlay`                |
 | `teaserHeader`                         |
+| `teaserImageContainer`                 |
 | `teaserImage`                          |
 | `teaserBody`                           |
 | `teaserSeparator`                      |

--- a/react/components/WordpressTeaser.tsx
+++ b/react/components/WordpressTeaser.tsx
@@ -35,6 +35,7 @@ const sanitizerConfigStripAll = {
 
 const CSS_HANDLES = [
   'teaserContainer',
+  'teaserImageContainer',
   'teaserImage',
   'teaserTextOverlay',
   'teaserTextOverlayTitle',
@@ -215,7 +216,7 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
           ) : (
             <Fragment>
               {absoluteLinks ? (
-                <Link to={link} target="_blank" className="tc-m db">
+                <Link to={link} target="_blank" className={`${handles.teaserImageContainer} tc-m db`}>
                   <img
                     className={`${handles.teaserImage}`}
                     src={image}
@@ -230,7 +231,7 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
                     slug_id: slug,
                     customdomainslug: customDomainSlug,
                   }}
-                  className="tc-m db"
+                  className={`${handles.teaserImageContainer} tc-m db`}
                 >
                   <img
                     className={`${handles.teaserImage}`}


### PR DESCRIPTION
**What problem is this solving?**

This adds a CSS handle on the Link that wraps the image of a related article.   It is needed to customize the how the 3 elements inside the main vtex-card are displayed.   We can't use display grid on them without a class on each child.

**How should this be manually tested?**

New version linked on https://razvanudream--fstudio.myvtex.com/ (which is a dev environment) OR can be seen here
![image](https://user-images.githubusercontent.com/71461884/105975450-a3d67080-6097-11eb-8d74-7fd8ec43cd90.png)
