### PR TITLE
OnRowsChange value must be a number format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Related Product Shelf not being displayed
+- Items Per Page selector in Pagination component
 
 ## [2.4.1] - 2021-01-26
 

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
+import type { ChangeEvent } from 'react'
 import React, { Fragment, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { defineMessages } from 'react-intl'
@@ -56,7 +57,7 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
       textOf="of"
       textShowRows="posts per page"
       totalItems={data?.wpPosts?.total_count ?? 0}
-      onRowsChange={(event: any) => {
+      onRowsChange={({target: {value}}: ChangeEvent<HTMLInputElement> ) => {
         setPage(1)
         if (pages[id].path.indexOf(':page') > 0) {
           params.page = '1'
@@ -68,11 +69,11 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
         } else {
           setQuery({ page: '1' })
         }
-        setPerPage(event.target.value)
+        setPerPage(+value)
         fetchMore({
           variables: {
             wp_page: 1,
-            wp_per_page: event.target.value,
+            wp_per_page: +value,
             customDomain,
           },
           updateQuery: (prev, { fetchMoreResult }) => {

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { Fragment, useState } from 'react'
+import React, { ChangeEvent, Fragment, useState } from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -71,7 +71,7 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
       textOf="of"
       textShowRows="posts per page"
       totalItems={data?.wpCategories?.categories[0]?.wpPosts?.total_count ?? 0}
-      onRowsChange={(event: any) => {
+      onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
         setPage(1)
         if (pages[id].path.indexOf(':page') > 0) {
           params.page = '1'
@@ -83,11 +83,11 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
         } else {
           setQuery({ page: '1' })
         }
-        setPerPage(event.target.value)
+        setPerPage(+value)
         fetchMore({
           variables: {
             wp_page: 1,
-            wp_per_page: event.target.value,
+            wp_per_page: +value,
             customDomain,
             ...categoryVariable,
           },

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { Fragment, useState } from 'react'
+import React, { ChangeEvent, Fragment, useState } from 'react'
 import { defineMessages } from 'react-intl'
 import { useQuery } from 'react-apollo'
 import { Spinner, Pagination } from 'vtex.styleguide'
@@ -53,13 +53,13 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
       textOf="of"
       textShowRows="posts per page"
       totalItems={data?.wpPosts?.total_count ?? 0}
-      onRowsChange={(event: any) => {
+      onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
         setPage(1)
-        setPerPage(event.target.value)
+        setPerPage(+value)
         fetchMore({
           variables: {
             wp_page: 1,
-            wp_per_page: event.target.value,
+            wp_per_page: +value,
             terms: searchQuery.data.searchMetadata.titleTag,
             customDomain,
           },

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { Fragment, useState } from 'react'
+import React, { ChangeEvent, Fragment, useState } from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -76,7 +76,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
       textOf="of"
       textShowRows="posts per page"
       totalItems={data?.wpPosts?.total_count ?? 0}
-      onRowsChange={(event: any) => {
+      onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
         setPage(1)
         if (pages[id].path.indexOf(':page') > 0) {
           params.page = '1'
@@ -88,11 +88,11 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
         } else {
           setQuery({ page: '1' })
         }
-        setPerPage(event.target.value)
+        setPerPage(+value)
         fetchMore({
           variables: {
             wp_page: 1,
-            wp_per_page: event.target.value,
+            wp_per_page: +value,
             terms: term,
             customDomain,
           },


### PR DESCRIPTION
**What problem is this solving?**

Posts Per Page option does not change the posts displayed. Caused by the value in the request being type `string` and not `number`.

```
apollo.min.js?async=2&workspace=master:2 Uncaught (in promise) Error: GraphQL error: Variable "$wp_per_page" got invalid value "20"; Expected type Int. Int cannot represent non-integer value: "20"
    at new t (apollo.min.js?async=2&workspace=master:2)
    at apollo.min.js?async=2&workspace=master:2
    at Object.next (common.min.js?async=2&workspace=master:2)
    at g (common.min.js?async=2&workspace=master:2)
    at b (common.min.js?async=2&workspace=master:2)
    at e.value (common.min.js?async=2&workspace=master:2)
    at apollo.min.js?async=2&workspace=master:2
    at Set.forEach (<anonymous>)
    at Object.next (apollo.min.js?async=2&workspace=master:2)
    at g (common.min.js?async=2&workspace=master:2)
```
<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

[workspace](https://sdb2--arteni.myvtex.com/blog?__bindingAddress=www.arteni.it/it&page=1)

