### PR TITLE
Feature/sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Support sku-selector inside related product shelf
+
 ## [2.4.4] - 2021-02-03
 
 ## [2.4.3] - 2021-02-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add Blog posts and categories to sitemap
+
 ### Fixed
 
 - Support sku-selector inside related product shelf

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,9 @@ In your VTEX account's admin, perform the following actions:
 2. Select the **Wordpress Integration** app box.
 3. In the Settings section, enter your **Wordpress URL**. This should be the domain where the Wordpress API endpoint is hosted and Wordpress is administered.
 4. If your Wordpress installation's API is hosted under a path other than `wp-json/wp/v2/`, enter the path in the **Wordpress API path** field. For example, if the `posts` endpoint looks like `https://example.wordpress.com/index.php?rest_route=/wp/v2/posts`, enter `index.php?rest_route=/wp/v2/` here. If unsure, leave the field blank.
-5. Enter then the **Title tag for block homepage** which will determine the title tag for the Wordpress portions of your store.
-6. Save your changes.
+5. Enter the **Title tag for block homepage** which will determine the title tag for the Wordpress portions of your store.
+6. Enter the **Store blog home path** which is used to include Wordpress posts in the stores sitemap and be indexed by search engines.
+7. Save your changes.
 
 ### Step 3 - Creating the blog pages
 

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,7 @@
     "vtex.store": "2.x",
     "vtex.styleguide": "9.x",
     "vtex.store-components": "3.x",
+    "vtex.store-sitemap": "2.x",
     "vtex.shelf": "1.x",
     "vtex.product-summary": "2.x",
     "vtex.product-context": "0.x",
@@ -59,6 +60,11 @@
         "title": "Title tag for blog homepage",
         "description": "Will also be appended to inner blog pages",
         "type": "string"
+      },
+      "blogPath": {
+        "title": "Store blog home path",
+        "description": "The app adds blog URLs to the sitemap, allowing for these pages to be index by search engines. Enter the path used to the store's blog home page, as found in the theme's `routes.json` file. Enter the string used without a beginning or ending slash, if '/blog', simply enter 'blog'",
+        "type": "string"
       }
     }
   },
@@ -76,6 +82,9 @@
         "host": "*",
         "path": "/wp-json/wp/v2/*"
       }
+    },
+    {
+      "name": "vtex.store-sitemap:resolve-graphql"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,5 +1,6 @@
 import { ClientsConfig, IOClients, LRUCache } from '@vtex/api'
 
+import Sitemap from './sitemap'
 import WordpressProxyDataSource from './wordpressProxy'
 
 const TIMEOUT_MS = 8000
@@ -16,6 +17,10 @@ metrics.trackCache('wordpressProxy', cacheStorage)
 export class Clients extends IOClients {
   public get wordpressProxy() {
     return this.getOrSet('wordpressProxy', WordpressProxyDataSource)
+  }
+
+  public get sitemap() {
+    return this.getOrSet('sitemap', Sitemap)
   }
 }
 

--- a/node/clients/sitemap.ts
+++ b/node/clients/sitemap.ts
@@ -1,0 +1,50 @@
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { AppGraphQLClient } from '@vtex/api'
+
+const saveIndexMutation = `mutation SaveIndex($index: String!) {
+    saveIndex(index: $index)
+}`
+
+export default class Sitemap extends AppGraphQLClient {
+  constructor(ctx: IOContext, opts?: InstanceOptions) {
+    super('vtex.store-sitemap@2.x', ctx, opts)
+  }
+
+  public async hasSitemap() {
+    const sitemap = await this.http.get(
+      `http://${this.context.workspace}--${this.context.account}.myvtex.com/sitemap.xml`
+    )
+
+    return sitemap.indexOf('blog-posts') !== -1
+  }
+
+  public async saveIndex() {
+    const { tenant } = this.context
+
+    const options = {
+        headers: {
+          ...this.options?.headers,
+          'Proxy-Authorization': this.context.authToken,
+          VtexIdclientAutCookie: this.context.authToken,
+          'x-vtex-tenant': tenant,
+        },
+        metric: 'wordpress-save-root-index',
+    }
+
+    this.graphql.mutate(
+      {
+        mutate: saveIndexMutation,
+        variables: { index: 'blog-posts' },
+      },
+      options
+    )
+
+    this.graphql.mutate(
+      {
+        mutate: saveIndexMutation,
+        variables: { index: 'blog-categories' },
+      },
+      options
+    )
+  }
+}

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,6 +1,7 @@
 import { Service } from '@vtex/api'
 
 import { queries } from './resolvers/index'
+import { routes } from './resolvers/routes'
 import { postResolvers } from './resolvers/postResolvers'
 import { pageResolvers } from './resolvers/pageResolvers'
 import { titleResolvers } from './resolvers/titleResolvers'
@@ -11,6 +12,9 @@ import { clients } from './clients'
 
 export default new Service({
   clients,
+  routes: {
+    ...routes,
+  },
   graphql: {
     resolvers: {
       Query: {

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,3 +1,5 @@
+import { LogLevel } from '@vtex/api'
+
 /* eslint-disable @typescript-eslint/camelcase */
 export const queries = {
   wpPosts: async (
@@ -26,30 +28,41 @@ export const queries = {
     }: {
       page: number
       per_page: number
-      search: string
-      after: string
-      author: [number]
-      author_exclude: [number]
-      before: string
-      exclude: [number]
-      include: [number]
-      offset: number
+      search?: string
+      after?: string
+      author?: [number]
+      author_exclude?: [number]
+      before?: string
+      exclude?: [number]
+      include?: [number]
+      offset?: number
       order: string
       orderby: string
-      slug: [string]
+      slug?: [string]
       status: [string]
-      categories: [number]
-      categories_exclude: [number]
-      tags: [number]
-      tags_exclude: [number]
-      sticky: boolean
-      customDomain: string
+      categories?: [number]
+      categories_exclude?: [number]
+      tags?: [number]
+      tags_exclude?: [number]
+      sticky?: boolean
+      customDomain?: string
     },
     ctx: Context
-  ) => {
+  ): Promise<{ posts: WpPost[]; total_count: string }> => {
     const {
-      clients: { wordpressProxy },
+      clients: { wordpressProxy, sitemap },
+      vtex: { logger },
     } = ctx
+
+    try {
+      const hasSitemap = await sitemap.hasSitemap()
+
+      if (!hasSitemap) {
+        sitemap.saveIndex()
+      }
+    } catch (err) {
+      logger.log(err, LogLevel.Error)
+    }
 
     const options = {
       page,
@@ -108,16 +121,16 @@ export const queries = {
     }: {
       page: number
       per_page: number
-      search: string
-      exclude: [number]
-      include: [number]
-      order: string
-      orderby: string
-      hide_empty: boolean
-      parent: number
-      post: number
-      slug: [string]
-      customDomain: string
+      search?: string
+      exclude?: [number]
+      include?: [number]
+      order?: string
+      orderby?: string
+      hide_empty?: boolean
+      parent?: number
+      post?: number
+      slug?: [string]
+      customDomain?: string
     },
     ctx: Context
   ) => {
@@ -181,16 +194,16 @@ export const queries = {
     }: {
       page: number
       per_page: number
-      search: string
-      exclude: [number]
-      include: [number]
-      offset: number
-      order: string
-      orderby: string
-      hide_empty: boolean
-      post: number
-      slug: [string]
-      customDomain: string
+      search?: string
+      exclude?: [number]
+      include?: [number]
+      offset?: number
+      order?: string
+      orderby?: string
+      hide_empty?: boolean
+      post?: number
+      slug?: [string]
+      customDomain?: string
     },
     ctx: Context
   ) => {

--- a/node/resolvers/routes.ts
+++ b/node/resolvers/routes.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { LogLevel, method } from '@vtex/api'
+import { queries } from './index'
+
+const API_MAX_QUANTITY = 100
+
+export const routes = {
+  postsSitemap: method({
+    GET: async (ctx: any) => {
+      const { blogPath = 'blog' } = await queries.appSettings(null, null, ctx)
+      const quantity = API_MAX_QUANTITY
+      let page = 1
+      let total = 0
+      let offset = 0
+
+      const sitemapContent = []
+
+      try {
+        do {
+          // eslint-disable-next-line no-await-in-loop
+          const response = await queries.wpPosts(
+            null,
+            {
+              page,
+              per_page: quantity,
+              order: 'desc',
+              orderby: 'date',
+              status: ['publish'],
+            },
+            ctx
+          )
+
+          const lastMod = new Date().toISOString()
+          const entries = response.posts?.map(post => {
+            return `<url>
+          <loc>https://${ctx.vtex.host}/${blogPath}/post/${post.slug}</loc>
+          <lastmod>${lastMod}</lastmod>
+          <changefreq>monthly</changefreq>
+          <priority>0.7</priority>
+       </url>`
+          })
+
+          if (entries) {
+            sitemapContent.push(...entries)
+          }
+
+          total = parseInt(response?.total_count, 10) || 0
+          offset += API_MAX_QUANTITY
+        } while (total > offset)
+
+        const sitemap = `
+          <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+           ${sitemapContent.join('')}</urlset>`
+
+        ctx.set('Content-Type', 'text/xml')
+        ctx.body = sitemap
+        ctx.status = 200
+      } catch (err) {
+        ctx.vtex.logger.log(err, LogLevel.Error)
+        ctx.body = err
+        ctx.status = 500
+      }
+    },
+  }),
+  categoriesSitemap: method({
+    GET: async (ctx: any) => {
+      const { blogPath = 'blog' } = await queries.appSettings(null, null, ctx)
+      const quantity = API_MAX_QUANTITY
+      let page = 1
+      let total = 0
+      let offset = 0
+
+      const sitemapContent = []
+
+      try {
+        do {
+          // eslint-disable-next-line no-await-in-loop
+          const response = await queries.wpCategories(
+            null,
+            {
+              page,
+              per_page: quantity,
+              order: 'desc',
+              orderby: 'name',
+              hide_empty: true,
+            },
+            ctx
+          )
+
+          const lastMod = new Date().toISOString()
+          const entries = response.categories?.map((category: any) => {
+            return `<url>
+          <loc>https://${ctx.vtex.host}/${blogPath}/category/${category.slug}</loc>
+          <lastmod>${lastMod}</lastmod>
+          <changefreq>monthly</changefreq>
+          <priority>0.7</priority>
+       </url>`
+          })
+
+          if (entries) {
+            sitemapContent.push(...entries)
+          }
+
+          total = parseInt(response?.total_count, 10) || 0
+          offset += API_MAX_QUANTITY
+        } while (total > offset)
+
+        const sitemap = `
+          <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+           ${sitemapContent.join('')}</urlset>`
+
+        ctx.set('Content-Type', 'text/xml')
+        ctx.body = sitemap
+        ctx.status = 200
+      } catch (err) {
+        ctx.vtex.logger.log(err, LogLevel.Error)
+        ctx.body = err
+        ctx.status = 500
+      }
+    },
+  }),
+}

--- a/node/service.json
+++ b/node/service.json
@@ -1,0 +1,16 @@
+{
+  "stack": "nodejs",
+  "memory": 1024,
+  "ttl": 300,
+  "timeout": 60,
+  "routes": {
+    "postsSitemap": {
+      "path": "/sitemap/blog-posts.xml",
+      "public": true
+    },
+    "categoriesSitemap": {
+      "path": "/sitemap/blog-categories.xml",
+      "public": true
+    }
+  }
+}

--- a/node/typings/wordpress.d.ts
+++ b/node/typings/wordpress.d.ts
@@ -1,0 +1,26 @@
+interface WpPost {
+  id: number
+  date: string
+  date_gmt: string
+  guid: any
+  modified: string
+  modified_gmt: string
+  slug: string
+  status: 'publish'
+  type: 'post'
+  link: string
+  title: any
+  content: any
+  excerpt: any
+  author: number
+  featured_media: number
+  comment_status: 'open'
+  ping_status: 'open'
+  sticky: boolean
+  template: string
+  format: 'standard'
+  meta: string[]
+  categories: string[]
+  tags: string[]
+  _links: any
+}

--- a/react/components/WordpressBreadcrumb.tsx
+++ b/react/components/WordpressBreadcrumb.tsx
@@ -39,6 +39,7 @@ const WordpressCategoryBreadcrumb: FunctionComponent<CategoryProps> = ({
   const handles = useCssHandles(CSS_HANDLES)
   const { data, loading, error } = useQuery(CategorySimpleBySlug, {
     variables: { categorySlug, customDomain },
+    skip: !categorySlug,
   })
   if (loading || error) return <Fragment></Fragment>
   if (data?.wpCategories?.categories?.length)

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -61,6 +61,7 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
   const { loading: loadingS, data: dataS } = useQuery(Settings)
   const { loading, error, data, fetchMore } = useQuery(CategoryPostsBySlug, {
     variables: { ...categoryVariable, ...initialPageVars, customDomain },
+    skip: !categoryVariable.categorySlug,
   })
 
   const PaginationComponent = (

--- a/react/graphql/ProductsByReference.graphql
+++ b/react/graphql/ProductsByReference.graphql
@@ -38,6 +38,11 @@ query ProductsByReference($ids: [ID!]) {
           ListPrice
         }
       }
+      variations {
+        originalName
+        name
+        values
+      }
     }
     productClusters {
       id


### PR DESCRIPTION
**What problem is this solving?**

-Adds blog posts and categories to the site sitemap.
-Expanded product query to get data needed to allow sku-selector in referenced product shelf
<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

Sitemap:
[root](https://sitemap--arteni.myvtex.com/sitemap.xml)
[posts](https://sitemap--arteni.myvtex.com/sitemap/blog-posts.xml)
[categories](https://sitemap--arteni.myvtex.com/sitemap/blog-categories.xml)

Related Products Shelf with sku selector
[workspace](https://sitemap--arteni.myvtex.com/blog/post/sneakers-sneakers-sneakers)
