### PR TITLE
Check params before acessing customdomainslug on breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `WordpressBreadcrumb` component: handle undefined `params` object
+
 ## [2.5.1] - 2021-02-05
 
 ### Fixed

--- a/react/components/WordpressBreadcrumb.tsx
+++ b/react/components/WordpressBreadcrumb.tsx
@@ -115,8 +115,8 @@ const WordpressBreadcrumb: StorefrontFunctionComponent<Props> = ({
   }
 
   const customDomain =
-    params.customdomainslug && parsedCustomDomains
-      ? parsedCustomDomains[params.customdomainslug]
+    params?.customdomainslug && parsedCustomDomains
+      ? parsedCustomDomains[params?.customdomainslug]
       : undefined
 
   // if we're on a category page with a slug


### PR DESCRIPTION
**What problem is this solving?**

Error "Cannot read property 'customdomainslug' of undefined" when acessing blog category page with breadcrumb block

**How should this be manually tested?**

Click on any blog category on [this workspace](https://blog--carrefourbrfood.myvtex.com/blog/dica-amiga/)

**Screenshots or example usage:**