### PR TITLE
Fix/multi bindings sitemap generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fetch all Post/Categories query in sitemap generation endpoint
+- Add sitemap entries to all sitemaps when multiple bindings are used
 
 ## [2.5.2] - 2021-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fetch all Post/Categories query in sitemap generation endpoint
+
 ## [2.5.2] - 2021-02-22
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,8 +25,10 @@ In your VTEX account's admin, perform the following actions:
 3. In the Settings section, enter your **Wordpress URL**. This should be the domain where the Wordpress API endpoint is hosted and Wordpress is administered.
 4. If your Wordpress installation's API is hosted under a path other than `wp-json/wp/v2/`, enter the path in the **Wordpress API path** field. For example, if the `posts` endpoint looks like `https://example.wordpress.com/index.php?rest_route=/wp/v2/posts`, enter `index.php?rest_route=/wp/v2/` here. If unsure, leave the field blank.
 5. Enter the **Title tag for block homepage** which will determine the title tag for the Wordpress portions of your store.
-6. Enter the **Store blog home path** which is used to include Wordpress posts in the stores sitemap and be indexed by search engines.
+6. Enter the **Store blog home path** which is used to include Wordpress posts in the sitemap and be indexed by search engines. For example, the path to your store's blog is www.my-store.com/blog, you would enter 'blog'.
 7. Save your changes.
+
+:information_source: _The settings option `Create Sitemap Entries` will likely not need to be modified. This setting tells the app to create the initial sitemap entries. Once this is done, the app programmatically updates this setting to prevent duplicate sitemap entires._
 
 ### Step 3 - Creating the blog pages
 
@@ -58,7 +60,7 @@ It is time to create the store pages that will host the blog content. Before per
 }
 ```
 
-:information*source: \_You may change `blog` in each route to another string of your choosing.*
+:information_source: _You may change `blog` in each route to another string of your choosing._
 
 | Blog page                  | Description                                                                                                                             |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
@@ -189,7 +191,7 @@ Starting with version 1.6.0 of this app, blog content from **multiple WordPress 
 
 To accomplish this, a `customdomainslug` parameter must be added to your blog routes, and your WordPress blocks must be updated with various props.
 
-:information*source: \_This configuration is not required if you only wish to display blog content from a single WordPress domain.*
+:information_source: _This configuration is not required if you only wish to display blog content from a single WordPress domain._
 
 #### Step 1 - Adding the `customdomainslug` parameter
 
@@ -241,7 +243,7 @@ For example, if you wanted URLs with the slug `blog` to load content from `http:
 }
 ```
 
-:information*source: \_Make sure to follow the format of the example value, including the brackets and escaped double quotes.*
+:information_source: _Make sure to follow the format of the example value, including the brackets and escaped double quotes._
 
 Blocks that do not use URL params should be given a different set of props, namely `customDomainSlug` and `customDomain`. These blocks are:
 
@@ -295,7 +297,7 @@ Continuing the example from above, any block that shows content from the "defaul
   },
 ```
 
-:information*source: \_Make sure to follow the format of the example value, including the brackets and escaped double quotes.*
+:information_source: _Make sure to follow the format of the example value, including the brackets and escaped double quotes._
 
 ## Customization
 

--- a/manifest.json
+++ b/manifest.json
@@ -38,9 +38,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "settingsSchema": {
     "title": "Wordpress Integration",
@@ -65,6 +63,12 @@
         "title": "Store blog home path",
         "description": "The app adds blog URLs to the sitemap, allowing for these pages to be index by search engines. Enter the path used to the store's blog home page, as found in the theme's `routes.json` file. Enter the string used without a beginning or ending slash, if '/blog', simply enter 'blog'",
         "type": "string"
+      },
+      "initializeSitemap": {
+        "title": "Create Sitemap Entries",
+        "description": "Create the initial sitemap entries (/blog-posts and /blog-categories) in the stores root sitemap. If setting up the app for the first time, leave this enabled so the sitemap is updated with these entries. If this is not the first time you have set up the Wordpress app, ensure the sitemap entries are not in your sitemap before changing this setting, it could result in duplicate sitemap entries.",
+        "type": "boolean",
+        "default": true
       }
     }
   },
@@ -85,6 +89,9 @@
     },
     {
       "name": "vtex.store-sitemap:resolve-graphql"
+    },
+    {
+      "name": "update-app-settings"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/clients/sitemap.ts
+++ b/node/clients/sitemap.ts
@@ -1,50 +1,80 @@
-import type { InstanceOptions, IOContext } from '@vtex/api'
+import { InstanceOptions, IOContext } from '@vtex/api'
 import { AppGraphQLClient } from '@vtex/api'
 
 const saveIndexMutation = `mutation SaveIndex($index: String!) {
     saveIndex(index: $index)
 }`
 
+const STOREFRONT = 'vtex-storefront'
+
 export default class Sitemap extends AppGraphQLClient {
   constructor(ctx: IOContext, opts?: InstanceOptions) {
     super('vtex.store-sitemap@2.x', ctx, opts)
   }
 
-  public async hasSitemap() {
-    const sitemap = await this.http.get(
-      `http://${this.context.workspace}--${this.context.account}.myvtex.com/sitemap.xml`
-    )
+  public async hasSitemap(ctx: Context) {
+    const {
+      clients: { apps },
+    } = ctx
 
-    return sitemap.indexOf('blog-posts') !== -1
-  }
+    const appId = process.env.VTEX_APP_ID
 
-  public async saveIndex() {
-    const { tenant } = this.context
-
-    const options = {
-        headers: {
-          ...this.options?.headers,
-          'Proxy-Authorization': this.context.authToken,
-          VtexIdclientAutCookie: this.context.authToken,
-          'x-vtex-tenant': tenant,
-        },
-        metric: 'wordpress-save-root-index',
+    if (!appId) {
+      return true
     }
 
-    this.graphql.mutate(
-      {
-        mutate: saveIndexMutation,
-        variables: { index: 'blog-posts' },
-      },
-      options
-    )
+    const settings = await apps.getAppSettings(appId)
 
-    this.graphql.mutate(
-      {
-        mutate: saveIndexMutation,
-        variables: { index: 'blog-categories' },
+    if (settings.initializeSitemap) {
+      settings.initializeSitemap = false
+      await apps.saveAppSettings(appId, settings)
+
+      return false
+    }
+
+    return true
+  }
+
+  public async saveIndex(ctx: Context) {
+    const { tenant } = ctx.clients
+    const tenantInfo = await tenant.info()
+    const options = {
+      headers: {
+        ...this.options?.headers,
+        'Proxy-Authorization': this.context.authToken,
+        VtexIdclientAutCookie: this.context.authToken,
       },
-      options
-    )
+      metric: 'wordpress-save-root-index',
+    }
+
+    const requests = []
+
+    for (const bindingInfo of tenantInfo.bindings) {
+      if (bindingInfo.targetProduct === STOREFRONT) {
+        const binding = bindingInfo.id || ''
+
+        requests.push(
+          this.graphql.mutate(
+            {
+              mutate: saveIndexMutation,
+              variables: { index: 'blog-posts', binding },
+            },
+            options
+          )
+        )
+
+        requests.push(
+          this.graphql.mutate(
+            {
+              mutate: saveIndexMutation,
+              variables: { index: 'blog-categories', binding },
+            },
+            options
+          )
+        )
+      }
+    }
+
+    await Promise.all(requests)
   }
 }

--- a/node/package.json
+++ b/node/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/he": "^1.1.0",
     "@types/sanitize-html": "^1.20.2",
-    "@vtex/api": "6.39.0",
+    "@vtex/api": "6.40.0",
     "vtex.blog-interfaces": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.blog-interfaces@0.2.0/public/@types/vtex.blog-interfaces",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context",

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -55,10 +55,10 @@ export const queries = {
     } = ctx
 
     try {
-      const hasSitemap = await sitemap.hasSitemap()
+      const hasSitemap = await sitemap.hasSitemap(ctx)
 
       if (!hasSitemap) {
-        sitemap.saveIndex()
+        sitemap.saveIndex(ctx)
       }
     } catch (err) {
       logger.log(err, LogLevel.Error)

--- a/node/resolvers/routes.ts
+++ b/node/resolvers/routes.ts
@@ -11,7 +11,7 @@ export const routes = {
       const quantity = API_MAX_QUANTITY
       let page = 1
       let total = 0
-      let offset = 0
+      let runningTotal = 0
 
       const sitemapContent = []
 
@@ -45,12 +45,13 @@ export const routes = {
           }
 
           total = parseInt(response?.total_count, 10) || 0
-          offset += API_MAX_QUANTITY
-        } while (total > offset)
+          runningTotal += API_MAX_QUANTITY
+          page += 1
+        } while (total > runningTotal)
 
         const sitemap = `
-          <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-           ${sitemapContent.join('')}</urlset>`
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+        ${sitemapContent.join('')}</urlset>`
 
         ctx.set('Content-Type', 'text/xml')
         ctx.body = sitemap
@@ -68,7 +69,7 @@ export const routes = {
       const quantity = API_MAX_QUANTITY
       let page = 1
       let total = 0
-      let offset = 0
+      let runningTotal = 0
 
       const sitemapContent = []
 
@@ -102,8 +103,9 @@ export const routes = {
           }
 
           total = parseInt(response?.total_count, 10) || 0
-          offset += API_MAX_QUANTITY
-        } while (total > offset)
+          runningTotal += API_MAX_QUANTITY
+          page += 1
+        } while (total > runningTotal)
 
         const sitemap = `
           <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -160,10 +160,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.39.0":
-  version "6.39.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.0.tgz#5f5b6c54713f4e3c6671d86feb3faec543b449f2"
-  integrity sha512-YoHLnMb0V2LMxoXQgIskbsHNkG/TprXjsE60RItHNjALx2b6/+gYFLSa8x/sJp+O6OJQQT3pSkFT7Ff5A8ER9g==
+"@vtex/api@6.40.0":
+  version "6.40.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.40.0.tgz#830c4aaaad75a1a8cf86ce898010e081a89053f8"
+  integrity sha512-VDdg9KVoNQ6KxH6cM0Tgh+VF7ELLrORqk5lRaie4akUZXW2tqECFLZAvRi9UE29CLstqCLBGQjqxbuT1aj/mgQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
**What problem is this solving?**

Two corrected issues:

- The `page` parameter was not being increased when querying all posts and categories for the sitemap, causing the same 100 post/categories being returned when fetching all items. 

- Sitemap generation did not take into account stores that have multiple bindings, with separate sitemaps. This resulted in duplicated sitemap entries.

This PR removes the check of the existing sitemap, and instead relies on an added app settings to initialize the sitemap Wordpress entries. The app setting, `initializeSitemap`, will default to `true`, and add the 'blog-posts' and 'blog-categories' entries to the sitemap. The `initializeSitemap` setting will be switched to false, preventing any duplicated entries.

If the sitemap gets reset, and the entries are need to be added again, the process can be reset in the app settings. 

**How should this be manually tested?**

[workspace](https://sdb--arteni.myvtex.com/admin/apps/vtex.wordpress-integration@2.5.2/setup/)

**Screenshots or example usage:**

![Screenshot from 2021-03-04 10-49-15](https://user-images.githubusercontent.com/22715037/110006864-5a50f500-7cd7-11eb-9b36-d56141e8c96a.png)
