### PR TITLE
Try/catch for author and featured media page resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Implement try/catch for author and featured_media page resolvers so that pages can still be displayed if author or media details can't be accessed
+
 ## [2.5.3] - 2021-03-04
 
 ### Fixed

--- a/node/resolvers/pageResolvers.ts
+++ b/node/resolvers/pageResolvers.ts
@@ -8,7 +8,12 @@ export const pageResolvers = {
     const {
       clients: { wordpressProxy },
     } = ctx
-    return wordpressProxy.getUser(author, customDomain)
+    try {
+      return await wordpressProxy.getUser(author, customDomain)
+    } catch (e) {
+      console.error(e)
+    }
+    return null
   },
   featured_media: async (
     {
@@ -21,9 +26,13 @@ export const pageResolvers = {
     const {
       clients: { wordpressProxy },
     } = ctx
-    if (featured_media === 0) {
-      return null
+    if (featured_media > 0) {
+      try {
+        return await wordpressProxy.getMediaSingle(featured_media, customDomain)
+      } catch (e) {
+        console.error(e)
+      }
     }
-    return wordpressProxy.getMediaSingle(featured_media, customDomain)
+    return null
   },
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1336,7 +1336,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
**What problem is this solving?**

In some WordPress installations, user data is not available through the REST API without authentication. For a Wordpress `page`, this would mean that the author resolver would throw an error and the entire page content would not load. We already implemented a try/catch block for the author resolver on WordPress `posts`, but not on `pages` due to an oversight. This PR makes the resolvers for posts and pages consistent. 

**How should this be manually tested?**

New version linked here: https://chef--poccarrefourarg.myvtex.com/blog/pages/productos-carrefour

This is a WordPress page from an account that does not allow user data to be accessed publicly.

GET page: https://uat-institucional.carrefour.com.ar/wp-json/wp/v2/pages/913
GET author: https://uat-institucional.carrefour.com.ar/wp-json/wp/v2/users/2