### PR TITLE
Add scroll to top on result pages after pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Scroll to top when page change
+
 ## [2.5.4] - 2021-03-08
 
 ### Fixed

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
 import type { ChangeEvent } from 'react'
-import React, { Fragment, useState, useEffect } from 'react'
+import React, { Fragment, useState, useEffect, useRef } from 'react'
 import { Helmet } from 'react-helmet'
 import { defineMessages } from 'react-intl'
 import { useQuery } from 'react-apollo'
@@ -48,12 +48,12 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
       customDomain,
     },
   })
-  
+
+  const containerRef = useRef<null | HTMLElement>(null)
+  const executeScroll = () => containerRef.current?.scrollIntoView()
+
   useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    })
+    executeScroll()
   }, [page])
 
   const PaginationComponent = (
@@ -147,6 +147,7 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
     <Container
       className={`${handles.listContainer} pt6 pb8`}
       style={{ maxWidth: '90%' }}
+      ref={containerRef}
     >
       {dataS?.appSettings?.titleTag && (
         <Helmet>

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
 import type { ChangeEvent } from 'react'
-import React, { Fragment, useState } from 'react'
+import React, { Fragment, useState, useEffect } from 'react'
 import { Helmet } from 'react-helmet'
 import { defineMessages } from 'react-intl'
 import { useQuery } from 'react-apollo'
@@ -48,6 +48,13 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
       customDomain,
     },
   })
+  
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }, [page])
 
   const PaginationComponent = (
     <Pagination

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect, useRef } from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -64,11 +64,11 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
     skip: !categoryVariable.categorySlug,
   })
 
+  const containerRef = useRef<null | HTMLElement>(null)
+  const executeScroll = () => containerRef.current?.scrollIntoView()
+
   useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    })
+    executeScroll()
   }, [page])
 
   const PaginationComponent = (
@@ -179,6 +179,7 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
       <Container
         className={`${handles.listContainer} pt2 pb8`}
         style={{ maxWidth: '90%' }}
+        ref={containerRef}
       >
         <div className="ph3">{PaginationComponent}</div>
         {(loading || loadingS) && (

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -63,6 +63,13 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
     variables: { ...categoryVariable, ...initialPageVars, customDomain },
     skip: !categoryVariable.categorySlug,
   })
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }, [page])
 
   const PaginationComponent = (
     <Pagination

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
 import { defineMessages } from 'react-intl'
 import { useQuery } from 'react-apollo'
 import { Spinner, Pagination } from 'vtex.styleguide'
@@ -44,6 +44,13 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
       customDomain,
     },
   })
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }, [page])
 
   const paginationComponent = (
     <Pagination

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect, useRef } from 'react'
 import { defineMessages } from 'react-intl'
 import { useQuery } from 'react-apollo'
 import { Spinner, Pagination } from 'vtex.styleguide'
@@ -45,11 +45,11 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
     },
   })
 
+  const containerRef = useRef<null | HTMLElement>(null)
+  const executeScroll = () => containerRef.current?.scrollIntoView()
+
   useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    })
+    executeScroll()
   }, [page])
 
   const paginationComponent = (
@@ -124,6 +124,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
       <Container
         className={`${handles.listContainer} ${handles.searchListContainer} pt2 pb8`}
         style={{ maxWidth: '90%' }}
+        ref={containerRef}
       >
         <div className="ph3">{paginationComponent}</div>
         {loading && (

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect, useRef } from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -64,11 +64,11 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
     },
   })
 
+  const containerRef = useRef<null | HTMLElement>(null)
+  const executeScroll = () => containerRef.current?.scrollIntoView()
+
   useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    })
+    executeScroll()
   }, [page])
 
   if (!params?.term && !params?.term_id) return null
@@ -185,6 +185,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
       <Container
         className={`${handles.listContainer} ${handles.searchListContainer} pt2 pb8`}
         style={{ maxWidth: '90%' }}
+        ref={containerRef}
       >
         <div className="ph3">{paginationComponent}</div>
         {(loading || loadingS) && (

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -63,6 +63,13 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
       customDomain,
     },
   })
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }, [page])
 
   if (!params?.term && !params?.term_id) return null
 


### PR DESCRIPTION
**What problem is this solving?**
Add scroll to top after user change page, this solve this kind of problem, maybe we can consider like a feature too:

https://user-images.githubusercontent.com/77166595/112997212-47e5a200-9143-11eb-8bbf-6eaeded5003b.mp4

<!--- What is the motivation and context for this change? -->
Clients are wondering about users changing page and not noticing it.

**How should this be manually tested?**
Go to any result page with Wordpress content, scroll to bottom pagination and click next/prev icon.

**Screenshots or example usage:**

https://user-images.githubusercontent.com/77166595/112996463-9181bd00-9142-11eb-88ad-0518fb9f2ca6.mp4

window.scrollTo compatibility: https://caniuse.com/?search=window.scrollTo

Any comments or code changes are welcome.