### PR TITLE
Feature/pagination scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Scroll to top when page change
+
 ## [2.5.4] - 2021-03-08
 
 ### Fixed

--- a/node/package.json
+++ b/node/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/he": "^1.1.0",
     "@types/sanitize-html": "^1.20.2",
-    "@vtex/api": "6.40.0",
+    "@vtex/api": "6.41.0",
     "vtex.blog-interfaces": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.blog-interfaces@0.2.0/public/@types/vtex.blog-interfaces",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1336,7 +1336,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -160,10 +160,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.40.0":
-  version "6.40.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.40.0.tgz#830c4aaaad75a1a8cf86ce898010e081a89053f8"
-  integrity sha512-VDdg9KVoNQ6KxH6cM0Tgh+VF7ELLrORqk5lRaie4akUZXW2tqECFLZAvRi9UE29CLstqCLBGQjqxbuT1aj/mgQ==
+"@vtex/api@6.41.0":
+  version "6.41.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.41.0.tgz#cee074ff49de8a5de92f3d353a4689275cb92f7b"
+  integrity sha512-RvfdpczsxCFacZkDSl2v2NmfD/bHFxHHn2xQsEwSQ+40snGxfOz56TlCbPbgMEtkC8Bf+1GGUkCIChRE6xnlLg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1336,7 +1336,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -50,8 +50,15 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
   })
 
   const containerRef = useRef<null | HTMLElement>(null)
+  const initialPageLoad = useRef(true)
 
   useEffect(() => {
+    if (initialPageLoad.current) {
+      initialPageLoad.current = false;
+
+      return
+    }
+    
     if (containerRef.current) {
       window.scrollTo({
         top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -50,11 +50,16 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
   })
 
   const containerRef = useRef<null | HTMLElement>(null)
-  const executeScroll = () => containerRef.current?.scrollIntoView()
 
   useEffect(() => {
-    executeScroll()
+    if (containerRef.current) {
+      window.scrollTo({
+        top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 
+        behavior: 'smooth'
+      });
+    }
   }, [page])
+
 
   const PaginationComponent = (
     <Pagination

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
 import type { ChangeEvent } from 'react'
-import React, { Fragment, useState, useEffect } from 'react'
+import React, { Fragment, useState, useEffect, useRef } from 'react'
 import { Helmet } from 'react-helmet'
 import { defineMessages } from 'react-intl'
 import { useQuery } from 'react-apollo'
@@ -48,12 +48,12 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
       customDomain,
     },
   })
-  
+
+  const containerRef = useRef<null | HTMLElement>(null)
+  const executeScroll = () => containerRef.current?.scrollIntoView()
+
   useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    })
+    executeScroll()
   }, [page])
 
   const PaginationComponent = (
@@ -147,6 +147,7 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
     <Container
       className={`${handles.listContainer} pt6 pb8`}
       style={{ maxWidth: '90%' }}
+      ref={containerRef}
     >
       {dataS?.appSettings?.titleTag && (
         <Helmet>

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
 import type { ChangeEvent } from 'react'
-import React, { Fragment, useState } from 'react'
+import React, { Fragment, useState, useEffect } from 'react'
 import { Helmet } from 'react-helmet'
 import { defineMessages } from 'react-intl'
 import { useQuery } from 'react-apollo'
@@ -48,6 +48,13 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
       customDomain,
     },
   })
+  
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }, [page])
 
   const PaginationComponent = (
     <Pagination

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -61,8 +61,8 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
     
     if (containerRef.current) {
       window.scrollTo({
-        top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 
-        behavior: 'smooth'
+        top: containerRef.current.getBoundingClientRect().top + window.pageYOffset - 100, 
+        behavior: 'smooth',
       });
     }
   }, [page])

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -65,8 +65,14 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
   })
 
   const containerRef = useRef<null | HTMLElement>(null)
+  const initialPageLoad = useRef(true)
 
   useEffect(() => {
+    if (initialPageLoad.current) {
+      initialPageLoad.current = false
+
+      return
+    }
     if (containerRef.current) {
       window.scrollTo({
         top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect, useRef } from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -64,11 +64,11 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
     skip: !categoryVariable.categorySlug,
   })
 
+  const containerRef = useRef<null | HTMLElement>(null)
+  const executeScroll = () => containerRef.current?.scrollIntoView()
+
   useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    })
+    executeScroll()
   }, [page])
 
   const PaginationComponent = (
@@ -179,6 +179,7 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
       <Container
         className={`${handles.listContainer} pt2 pb8`}
         style={{ maxWidth: '90%' }}
+        ref={containerRef}
       >
         <div className="ph3">{PaginationComponent}</div>
         {(loading || loadingS) && (

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -65,10 +65,14 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
   })
 
   const containerRef = useRef<null | HTMLElement>(null)
-  const executeScroll = () => containerRef.current?.scrollIntoView()
 
   useEffect(() => {
-    executeScroll()
+    if (containerRef.current) {
+      window.scrollTo({
+        top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 
+        behavior: 'smooth'
+      });
+    }
   }, [page])
 
   const PaginationComponent = (

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState, useEffect, useRef } from 'react'
+import React, {
+  ChangeEvent,
+  Fragment,
+  useState,
+  useEffect,
+  useRef,
+} from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -75,9 +81,12 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
     }
     if (containerRef.current) {
       window.scrollTo({
-        top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 
-        behavior: 'smooth'
-      });
+        top:
+          containerRef.current.getBoundingClientRect().top +
+          window.pageYOffset -
+          100,
+        behavior: 'smooth',
+      })
     }
   }, [page])
 

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -63,6 +63,13 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
     variables: { ...categoryVariable, ...initialPageVars, customDomain },
     skip: !categoryVariable.categorySlug,
   })
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }, [page])
 
   const PaginationComponent = (
     <Pagination

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState, useEffect, useRef } from 'react'
+import React, {
+  ChangeEvent,
+  Fragment,
+  useState,
+  useEffect,
+  useRef,
+} from 'react'
 import { defineMessages } from 'react-intl'
 import { useQuery } from 'react-apollo'
 import { Spinner, Pagination } from 'vtex.styleguide'
@@ -56,9 +62,12 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
     }
     if (containerRef.current) {
       window.scrollTo({
-        top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 
-        behavior: 'smooth'
-      });
+        top:
+          containerRef.current.getBoundingClientRect().top +
+          window.pageYOffset -
+          100,
+        behavior: 'smooth',
+      })
     }
   }, [page])
 

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
 import { defineMessages } from 'react-intl'
 import { useQuery } from 'react-apollo'
 import { Spinner, Pagination } from 'vtex.styleguide'
@@ -44,6 +44,13 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
       customDomain,
     },
   })
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }, [page])
 
   const paginationComponent = (
     <Pagination

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect, useRef } from 'react'
 import { defineMessages } from 'react-intl'
 import { useQuery } from 'react-apollo'
 import { Spinner, Pagination } from 'vtex.styleguide'
@@ -45,11 +45,11 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
     },
   })
 
+  const containerRef = useRef<null | HTMLElement>(null)
+  const executeScroll = () => containerRef.current?.scrollIntoView()
+
   useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    })
+    executeScroll()
   }, [page])
 
   const paginationComponent = (
@@ -124,6 +124,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
       <Container
         className={`${handles.listContainer} ${handles.searchListContainer} pt2 pb8`}
         style={{ maxWidth: '90%' }}
+        ref={containerRef}
       >
         <div className="ph3">{paginationComponent}</div>
         {loading && (

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -46,8 +46,14 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
   })
 
   const containerRef = useRef<null | HTMLElement>(null)
+  const initialPageLoad = useRef(true)
 
   useEffect(() => {
+    if (initialPageLoad.current) {
+      initialPageLoad.current = false
+
+      return
+    }
     if (containerRef.current) {
       window.scrollTo({
         top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -46,10 +46,14 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
   })
 
   const containerRef = useRef<null | HTMLElement>(null)
-  const executeScroll = () => containerRef.current?.scrollIntoView()
 
   useEffect(() => {
-    executeScroll()
+    if (containerRef.current) {
+      window.scrollTo({
+        top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 
+        behavior: 'smooth'
+      });
+    }
   }, [page])
 
   const paginationComponent = (

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect, useRef } from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -64,11 +64,11 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
     },
   })
 
+  const containerRef = useRef<null | HTMLElement>(null)
+  const executeScroll = () => containerRef.current?.scrollIntoView()
+
   useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    })
+    executeScroll()
   }, [page])
 
   if (!params?.term && !params?.term_id) return null
@@ -185,6 +185,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
       <Container
         className={`${handles.listContainer} ${handles.searchListContainer} pt2 pb8`}
         style={{ maxWidth: '90%' }}
+        ref={containerRef}
       >
         <div className="ph3">{paginationComponent}</div>
         {(loading || loadingS) && (

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState, useEffect, useRef } from 'react'
+import React, {
+  ChangeEvent,
+  Fragment,
+  useState,
+  useEffect,
+  useRef,
+} from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -75,9 +81,12 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
     }
     if (containerRef.current) {
       window.scrollTo({
-        top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 
-        behavior: 'smooth'
-      });
+        top:
+          containerRef.current.getBoundingClientRect().top +
+          window.pageYOffset -
+          100,
+        behavior: 'smooth',
+      })
     }
   }, [page])
 

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import React, { ChangeEvent, Fragment, useState } from 'react'
+import React, { ChangeEvent, Fragment, useState, useEffect } from 'react'
 import { useQuery } from 'react-apollo'
 import { defineMessages } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -63,6 +63,13 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
       customDomain,
     },
   })
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }, [page])
 
   if (!params?.term && !params?.term_id) return null
 

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -65,10 +65,14 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
   })
 
   const containerRef = useRef<null | HTMLElement>(null)
-  const executeScroll = () => containerRef.current?.scrollIntoView()
 
   useEffect(() => {
-    executeScroll()
+    if (containerRef.current) {
+      window.scrollTo({
+        top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 
+        behavior: 'smooth'
+      });
+    }
   }, [page])
 
   if (!params?.term && !params?.term_id) return null

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -65,8 +65,14 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
   })
 
   const containerRef = useRef<null | HTMLElement>(null)
+  const initialPageLoad = useRef(true)
 
   useEffect(() => {
+    if (initialPageLoad.current) {
+      initialPageLoad.current = false
+
+      return
+    }
     if (containerRef.current) {
       window.scrollTo({
         top: containerRef.current.getBoundingClientRect().top + window.pageYOffset, 


### PR DESCRIPTION
This is a continuation of the work done in PR #68 by @italo-aurelio. 

It adds a smooth scroll effect when the user selects the next page, and the browser returns to the top of the paginated list.

Test in these workspaces:

[workspace](https://sdb--arcaplanet.myvtex.com/blog/category/consigli?page=1)

[workspace](https://sdb--arteni.myvtex.com/blog/category/moda?__bindingAddress=www.arteni.it/it&page=1)