### PR TITLE
Feature/pagination list customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- CSS handle for post category links in post titles
+
 ## [2.6.1] - 2021-05-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add block prop to customize posts per page in paginated lists
 - CSS handle for post category links in post titles
 
 ## [2.6.1] - 2021-05-05

--- a/docs/README.md
+++ b/docs/README.md
@@ -185,6 +185,21 @@ The Wordpress Integration app provides the following blocks for your use:
 | `categoryIdentifier` | You may manually specify the ID to be used in the WordPress tag. For example, if you set this prop to "test", the block will look for a WordPress post tagged "category-test". | String                               | (empty string) |
 | `numberOfPosts`      | `number`                                                                                                                                                                       | The number of posts to be displayed. | `3`            |
 
+### Paginated List Customization
+
+Blocks that use a paginated list accept some common props that allow customization of the paginated list behavior.
+
+These blocks include:
+
+- `blog-all-posts.wordpress-all-posts`
+- `blog-category-list.wordpress-category-list`
+- `blog-search-list.wordpress-search-list`
+- `search-blog-articles-list.wordpress`
+
+| Prop Name      | Description                                            | Type   | Default value |
+| -------------- | ------------------------------------------------------ | ------ | ------------- |
+| `postsPerPage` | Number of posts to be displayed in the paginated list. | Number | `10`          |
+
 ### Advanced configuration
 
 Starting with version 1.6.0 of this app, blog content from **multiple WordPress installations** is supported.

--- a/docs/README.md
+++ b/docs/README.md
@@ -333,6 +333,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `postMeta`                             |
 | `postFeaturedImage`                    |
 | `postBody`                             |
+| `postCategoryLink`                     |
 | `postChildrenContainer`                |
 | `postNavigationContainer`              |
 | `postNavigationFlex`                   |

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
-import type { ChangeEvent } from 'react'
-import React, { Fragment, useState, useEffect, useRef } from 'react'
+import React, {
+  ChangeEvent,
+  Fragment,
+  useState,
+  useEffect,
+  useRef,
+} from 'react'
 import { Helmet } from 'react-helmet'
 import { defineMessages } from 'react-intl'
 import { useQuery } from 'react-apollo'
@@ -23,11 +28,13 @@ const CSS_HANDLES = [
 interface AllPostsProps {
   customDomain: string
   customDomainSlug: string
+  postsPerPage: number
 }
 
 const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
   customDomain,
   customDomainSlug,
+  postsPerPage,
 }) => {
   const {
     route: { id, params },
@@ -38,13 +45,13 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
   } = useRuntime() as any
   const initialPage = params.page ?? query?.page ?? '1'
   const [page, setPage] = useState(parseInt(initialPage, 10))
-  const [perPage, setPerPage] = useState(10)
+  const [perPage, setPerPage] = useState(postsPerPage)
   const handles = useCssHandles(CSS_HANDLES)
   const { loading: loadingS, data: dataS } = useQuery(Settings)
   const { loading, error, data, fetchMore } = useQuery(AllPosts, {
     variables: {
       wp_page: 1,
-      wp_per_page: 10,
+      wp_per_page: perPage,
       customDomain,
     },
   })
@@ -54,29 +61,36 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
 
   useEffect(() => {
     if (initialPageLoad.current) {
-      initialPageLoad.current = false;
+      initialPageLoad.current = false
 
       return
     }
-    
+
     if (containerRef.current) {
       window.scrollTo({
-        top: containerRef.current.getBoundingClientRect().top + window.pageYOffset - 100, 
+        top:
+          containerRef.current.getBoundingClientRect().top +
+          window.pageYOffset -
+          100,
         behavior: 'smooth',
-      });
+      })
     }
   }, [page])
 
-
   const PaginationComponent = (
     <Pagination
-      rowsOptions={[10, 20, 30, 40]}
+      rowsOptions={[
+        postsPerPage,
+        postsPerPage * 2,
+        postsPerPage * 3,
+        postsPerPage * 4,
+      ]}
       currentItemFrom={(page - 1) * perPage + 1}
       currentItemTo={page * perPage}
       textOf="of"
       textShowRows="posts per page"
       totalItems={data?.wpPosts?.total_count ?? 0}
-      onRowsChange={({target: {value}}: ChangeEvent<HTMLInputElement> ) => {
+      onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
         setPage(1)
         if (pages[id].path.indexOf(':page') > 0) {
           params.page = '1'
@@ -254,6 +268,7 @@ const messages = defineMessages({
 WordpressAllPosts.defaultProps = {
   customDomain: undefined,
   customDomainSlug: undefined,
+  postsPerPage: 10,
 }
 
 WordpressAllPosts.schema = {

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -20,6 +20,7 @@ import Settings from '../graphql/Settings.graphql'
 
 interface CategoryProps {
   customDomains: string
+  postsPerPage: number
 }
 
 const CSS_HANDLES = [
@@ -29,13 +30,9 @@ const CSS_HANDLES = [
   'listFlexItem',
 ] as const
 
-const initialPageVars = {
-  wp_page: 1,
-  wp_per_page: 10,
-}
-
 const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
   customDomains,
+  postsPerPage,
 }) => {
   const {
     route: { id, params },
@@ -59,14 +56,19 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
 
   const initialPage = params.page ?? query?.page ?? '1'
   const [page, setPage] = useState(parseInt(initialPage, 10))
-  const [perPage, setPerPage] = useState(10)
+  const [perPage, setPerPage] = useState(postsPerPage)
   const categoryVariable = {
     categorySlug: params.categoryslug || params.categoryslug_id,
   }
   const handles = useCssHandles(CSS_HANDLES)
   const { loading: loadingS, data: dataS } = useQuery(Settings)
   const { loading, error, data, fetchMore } = useQuery(CategoryPostsBySlug, {
-    variables: { ...categoryVariable, ...initialPageVars, customDomain },
+    variables: {
+      ...categoryVariable,
+      wp_page: 1,
+      wp_per_page: perPage,
+      customDomain,
+    },
     skip: !categoryVariable.categorySlug,
   })
 
@@ -92,7 +94,12 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
 
   const PaginationComponent = (
     <Pagination
-      rowsOptions={[10, 20, 30, 40]}
+      rowsOptions={[
+        postsPerPage,
+        postsPerPage * 2,
+        postsPerPage * 3,
+        postsPerPage * 4,
+      ]}
       currentItemFrom={(page - 1) * perPage + 1}
       currentItemTo={page * perPage}
       textOf="of"
@@ -280,6 +287,7 @@ const messages = defineMessages({
 
 WordpressCategory.defaultProps = {
   customDomains: undefined,
+  postsPerPage: 10,
 }
 
 WordpressCategory.schema = {

--- a/react/components/WordpressPost.tsx
+++ b/react/components/WordpressPost.tsx
@@ -119,6 +119,7 @@ const CSS_HANDLES = [
   'postFeaturedImage',
   'postBody',
   'postChildrenContainer',
+  'postCategoryLink',
 ] as const
 
 const WordpressPostInner: FunctionComponent<{
@@ -216,6 +217,7 @@ const WordpressPostInner: FunctionComponent<{
           {categories.map((cat: any, index: number) => (
             <span key={index}>
               <Link
+                className={handles.postCategoryLink}
                 page="store.blog-category"
                 params={{
                   categoryslug: cat.slug,

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -20,6 +20,7 @@ interface Props {
   searchQuery: any
   customDomain: string
   customDomainSlug: string
+  postsPerPage: number
 }
 
 const CSS_HANDLES = [
@@ -37,16 +38,17 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
   searchQuery,
   customDomain,
   customDomainSlug,
+  postsPerPage,
 }) => {
   const [page, setPage] = useState(1)
-  const [perPage, setPerPage] = useState(10)
+  const [perPage, setPerPage] = useState(postsPerPage)
   const handles = useCssHandles(CSS_HANDLES)
   const { loading, error, data, fetchMore } = useQuery(SearchPosts, {
     skip: !searchQuery,
     variables: {
       terms: searchQuery?.data?.searchMetadata?.titleTag ?? null,
       wp_page: 1,
-      wp_per_page: 10,
+      wp_per_page: perPage,
       customDomain,
     },
   })
@@ -73,7 +75,12 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
 
   const paginationComponent = (
     <Pagination
-      rowsOptions={[10, 20, 30, 40]}
+      rowsOptions={[
+        postsPerPage,
+        postsPerPage * 2,
+        postsPerPage * 3,
+        postsPerPage * 4,
+      ]}
       currentItemFrom={(page - 1) * perPage + 1}
       currentItemTo={page * perPage}
       textOf="of"
@@ -233,6 +240,7 @@ const messages = defineMessages({
 WordpressSearchResult.defaultProps = {
   customDomain: undefined,
   customDomainSlug: undefined,
+  postsPerPage: 10,
 }
 
 WordpressSearchResult.schema = {

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -20,6 +20,7 @@ import Settings from '../graphql/Settings.graphql'
 
 interface SearchProps {
   customDomains: string
+  postsPerPage: number
 }
 
 const CSS_HANDLES = [
@@ -35,6 +36,7 @@ const CSS_HANDLES = [
 
 const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
   customDomains,
+  postsPerPage,
 }) => {
   const {
     route: { id, params },
@@ -57,7 +59,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
 
   const initialPage = params.page ?? query?.page ?? '1'
   const [page, setPage] = useState(parseInt(initialPage, 10))
-  const [perPage, setPerPage] = useState(10)
+  const [perPage, setPerPage] = useState(postsPerPage)
   const handles = useCssHandles(CSS_HANDLES)
   const { loading: loadingS, data: dataS } = useQuery(Settings)
   const { loading, error, data, fetchMore } = useQuery(SearchPosts, {
@@ -96,7 +98,12 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
 
   const paginationComponent = (
     <Pagination
-      rowsOptions={[10, 20, 30, 40]}
+      rowsOptions={[
+        postsPerPage,
+        postsPerPage * 2,
+        postsPerPage * 3,
+        postsPerPage * 4,
+      ]}
       currentItemFrom={(page - 1) * perPage + 1}
       currentItemTo={page * perPage}
       textOf="of"
@@ -285,6 +292,7 @@ const messages = defineMessages({
 
 WordpressSearchResult.defaultProps = {
   customDomains: undefined,
+  postsPerPage: 10,
 }
 
 WordpressSearchResult.schema = {


### PR DESCRIPTION
**What problem is this solving?**

- Adds props to blocks containing a paginated list, allowing for the customization of the number of posts displayed in the list. Useful if the number of posts displayed needs to be controlled.

**How should this be manually tested?**

[workspace](https://sdb--arcaplanet.myvtex.com/blog/category/consigli?page=1)

**Screenshots or example usage:**

```
  "blog-category-list.wordpress-category-list": {
    "props": {
      "postsPerPage": 9
    }
  }
```

Ensuring no empty space in a list of posts.

Before:

![Screenshot from 2021-05-06 15-30-21](https://user-images.githubusercontent.com/22715037/117355732-f2f32500-ae80-11eb-9e2d-1d0614ec41f7.png)

After:

![Screenshot from 2021-05-06 15-30-31](https://user-images.githubusercontent.com/22715037/117355704-e8d12680-ae80-11eb-8c7f-2d196be1df0c.png)

