### PR TITLE
Feature/subcategory url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support subcategory use in blog URLs
+
 ## [2.8.0] - 2021-06-04
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -200,7 +200,9 @@ These blocks include:
 | -------------- | ------------------------------------------------------ | ------ | ------------- |
 | `postsPerPage` | Number of posts to be displayed in the paginated list. | Number | `10`          |
 
-### Advanced configuration
+## Advanced configuration
+
+### Multiple WordPress installations
 
 Starting with version 1.6.0 of this app, blog content from **multiple WordPress installations** is supported.
 
@@ -314,6 +316,53 @@ Continuing the example from above, any block that shows content from the "defaul
 
 :information_source: _Make sure to follow the format of the example value, including the brackets and escaped double quotes._
 
+### Adding Subcategories to blog URLs
+
+To have subcategories included in your blog URLs (`/blog/category/subcategory`), you will need to update your store's `routes.json`, as well as the theme's blocks that display category-related URLs.
+
+Add an additional category route including the `:categoryslug` and `:subcategoryslug_id` parameter:
+
+```json
+"store.blog-category": {
+	"path": "/blog/category/:categoryslug_id"
+},
+"store.blog-category#subcategory": {
+	"path": "/blog/category/:categoryslug/:subcategoryslug_id"
+},
+```
+
+Declare the subcategory block:
+
+```json
+"store.blog-category#subcategory": {
+  "blocks": [
+      "blog-category-list.wordpress-category-list"
+  ]
+},
+```
+
+Add the prop `subcategoryUrls` with a value of `true` to the blocks below:
+
+- 'blog-all-posts.wordpress-all-posts'
+- `blog-breadcrumb.wordpress-breadcrumb`
+- 'blog-category-list.wordpress-category-list'
+- 'blog-category-preview.wordpress-category-preview'
+- 'blog-latest-posts-preview.wordpress-latest-posts-preview'
+- `blog-post-details.wordpress-post-details`
+- 'blog-related-products.wordpress-related-products'
+- 'search-blog-articles-list.wordpress'
+- 'search-blog-articles-preview.wordpress'
+
+For example:
+
+```json
+"blog-all-posts.wordpress-all-posts": {
+  "props": {
+    "subcategoryUrls": true
+  }
+},
+```
+
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
@@ -346,6 +395,9 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `postContainer`                        |
 | `postTitle`                            |
 | `postMeta`                             |
+| `postMetaDate`                         |
+| `postMetaAuthor`                       |
+| `postMetaCategory`                     |
 | `postFeaturedImage`                    |
 | `postFeaturedImageContainer`           |
 | `postBody`                             |

--- a/messages/context.json
+++ b/messages/context.json
@@ -68,6 +68,8 @@
   "admin/editor.wordpressCustomDomains.description": "admin/editor.wordpressCustomDomains.description",
   "admin/editor.wordpressCustomDomainSlug.title": "admin/editor.wordpressCustomDomainSlug.title",
   "admin/editor.wordpressCustomDomainSlug.description": "admin/editor.wordpressCustomDomainSlug.description",
+  "admin/editor.wordpressSubcategoryUrls.title": "admin/editor.wordpressSubcategoryUrls.title",
+  "admin/editor.wordpressSubcategoryUrls.description": "admin/editor.wordpressSubcategoryUrls.description",
   "admin/editor.wordpressBreadcrumb.title": "admin/editor.wordpressBreadcrumb.title",
   "admin/editor.wordpressBreadcrumb.description": "admin/editor.wordpressBreadcrumb.description",
   "store/wordpress-integration.wordpressPostNavigation.next": "store/wordpress-integration.wordpressPostNavigation.next",

--- a/messages/en.json
+++ b/messages/en.json
@@ -70,6 +70,8 @@
   "admin/editor.wordpressCustomDomainSlug.description": "Enter the URL slug that will represent this Wordpress domain",
   "admin/editor.wordpressBreadcrumb.title": "Wordpress Breadcrumb",
   "admin/editor.wordpressBreadcrumb.description": "Displays a breadcrumb specific to your VTEX blog pages, i.e. 'Blog Home / (category) / (title of post)' ",
+  "admin/editor.wordpressSubcategoryUrls.title": "Subcategory URLs (optional)",
+  "admin/editor.wordpressSubcategoryUrls.description": "Include both category and subcategory in your blog URLs",
   "store/wordpress-integration.wordpressPostNavigation.next": "Next Article >",
   "store/wordpress-integration.wordpressPostNavigation.previous": "< Previous Article",
   "store/wordpress-integration.wordpressPost.postedIn": "Posted {formattedDate} in ",

--- a/messages/es.json
+++ b/messages/es.json
@@ -70,6 +70,8 @@
   "admin/editor.wordpressCustomDomainSlug.description": "Ingresar el slug de la URL que representará a este dominio de WordPress",
   "admin/editor.wordpressBreadcrumb.title": "Navegación de WordPress",
   "admin/editor.wordpressBreadcrumb.description": "Muestra una navegación específica para las páginas de su blog VTEX; es decir, 'Página de Inicio del Blog / (categoría) / (título del post)' ",
+  "admin/editor.wordpressSubcategoryUrls.title": "URLs de la subcategoría (opcional)",
+  "admin/editor.wordpressSubcategoryUrls.description": "Incluya la categoría y la subcategoría en las URL de su blog",
   "store/wordpress-integration.wordpressPostNavigation.next": "Siguiente Artículo >",
   "store/wordpress-integration.wordpressPostNavigation.previous": "< Artículo Anterior",
   "store/wordpress-integration.wordpressPost.postedIn": "Publicado {formattedDate} en ",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -70,6 +70,8 @@
   "admin/editor.wordpressCustomDomainSlug.description": "Insira o slug da URL que representará este domínio Wordpress",
   "admin/editor.wordpressBreadcrumb.title": "Breadcrumb Wordpress",
   "admin/editor.wordpressBreadcrumb.description": "Mostra um breadcrumb específico para as páginas do seu blog VTEX, ou seja, 'Página Inicial do Blog / (categoria) / (título do post)' ",
+  "admin/editor.wordpressSubcategoryUrls.title": "URLs da subcategoria (opcional)",
+  "admin/editor.wordpressSubcategoryUrls.description": "Inclua a categoria e a subcategoria nas URLs do seu blog",
   "store/wordpress-integration.wordpressPostNavigation.next": "Próximo Artigo >",
   "store/wordpress-integration.wordpressPostNavigation.previous": "< Artigo Anterior",
   "store/wordpress-integration.wordpressPost.postedIn": "Postado {formattedDate} em ",

--- a/node/clients/sitemap.ts
+++ b/node/clients/sitemap.ts
@@ -1,5 +1,4 @@
-import { InstanceOptions, IOContext } from '@vtex/api'
-import { AppGraphQLClient } from '@vtex/api'
+import { InstanceOptions, IOContext, AppGraphQLClient } from '@vtex/api'
 
 const saveIndexMutation = `mutation SaveIndex($index: String!) {
     saveIndex(index: $index)

--- a/node/package.json
+++ b/node/package.json
@@ -24,9 +24,9 @@
     "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.43.0/public/@types/vtex.search-graphql",
     "vtex.search-page-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-page-context@0.2.0/public/@types/vtex.search-page-context",
     "vtex.shelf": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shelf@1.44.2/public/_types/react",
-    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.116.0/public/@types/vtex.store",
-    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.143.1/public/@types/vtex.store-components",
-    "vtex.store-sitemap": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.8/public/@types/vtex.store-sitemap",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.140.0/public/@types/vtex.styleguide"
+    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.117.0/public/@types/vtex.store",
+    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.144.0/public/@types/vtex.store-components",
+    "vtex.store-sitemap": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.9/public/@types/vtex.store-sitemap",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.142.0/public/@types/vtex.styleguide"
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1881,21 +1881,21 @@ vary@^1.1.2:
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shelf@1.44.2/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.143.1/public/@types/vtex.store-components":
-  version "3.143.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.143.1/public/@types/vtex.store-components#e3ea200b8975e7e4631b625378b051e0e582d181"
+"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.144.0/public/@types/vtex.store-components":
+  version "3.144.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.144.0/public/@types/vtex.store-components#7731a0fb7cec831b93b5037c6f694205eb34a247"
 
-"vtex.store-sitemap@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.8/public/@types/vtex.store-sitemap":
-  version "2.13.8"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.8/public/@types/vtex.store-sitemap#b5c9a6d29d74d8deaab9a5c4f95d909fd94cc325"
+"vtex.store-sitemap@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.9/public/@types/vtex.store-sitemap":
+  version "2.13.9"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.9/public/@types/vtex.store-sitemap#88060df3db5dedfa04e15f37a331340780822001"
 
-"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.116.0/public/@types/vtex.store":
-  version "2.116.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.116.0/public/@types/vtex.store#ed1aaedd39b07a8e99b5bd303e5fdc45cb815a1d"
+"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.117.0/public/@types/vtex.store":
+  version "2.117.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.117.0/public/@types/vtex.store#9f7403d597b8927af64b520f4de62bda34dad3ab"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.140.0/public/@types/vtex.styleguide":
-  version "9.140.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.140.0/public/@types/vtex.styleguide#f3180d1ff13a4d93be89505740ca5527c6e12313"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.142.0/public/@types/vtex.styleguide":
+  version "9.142.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.142.0/public/@types/vtex.styleguide#12d22690aa1896a7516eb4b7bc8923216aed7725"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -28,12 +28,14 @@ const CSS_HANDLES = [
 interface AllPostsProps {
   customDomain: string
   customDomainSlug: string
+  subcategoryUrls: boolean
   postsPerPage: number
 }
 
 const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
   customDomain,
   customDomainSlug,
+  subcategoryUrls,
   postsPerPage,
 }) => {
   const {
@@ -202,9 +204,8 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
                 <WordpressTeaser
                   title={post.title.rendered}
                   author={post.author ? post.author.name : ''}
-                  category={post.categories[0]?.name ?? ''}
-                  categoryId={post.categories[0]?.id ?? undefined}
-                  categorySlug={post.categories[0]?.slug ?? ''}
+                  categories={data.wpPosts.posts[0].categories}
+                  subcategoryUrls={subcategoryUrls}
                   excerpt={post.excerpt.rendered}
                   date={post.date}
                   id={post.id}
@@ -263,11 +264,20 @@ const messages = defineMessages({
     defaultMessage: '',
     id: 'admin/editor.wordpressCustomDomainSlug.description',
   },
+  subcategoryUrlsTitle: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.title',
+  },
+  subcategoryUrlsDescription: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.description',
+  },
 })
 
 WordpressAllPosts.defaultProps = {
   customDomain: undefined,
   customDomainSlug: undefined,
+  subcategoryUrls: false,
   postsPerPage: 10,
 }
 
@@ -287,6 +297,13 @@ WordpressAllPosts.schema = {
       title: messages.customDomainSlugTitle.id,
       description: messages.customDomainSlugDescription.id,
       type: 'string',
+      isLayout: false,
+      default: '',
+    },
+    subcategoryUrls: {
+      title: messages.subcategoryUrlsTitle.id,
+      description: messages.subcategoryUrlsDescription.id,
+      type: 'boolean',
       isLayout: false,
       default: '',
     },

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -58,7 +58,10 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
   const [page, setPage] = useState(parseInt(initialPage, 10))
   const [perPage, setPerPage] = useState(postsPerPage)
   const categoryVariable = {
-    categorySlug: params.categoryslug || params.categoryslug_id,
+    categorySlug:
+      params.subcategoryslug_id ||
+      params.categoryslug ||
+      params.categoryslug_id,
   }
   const handles = useCssHandles(CSS_HANDLES)
   const { loading: loadingS, data: dataS } = useQuery(Settings)

--- a/react/components/WordpressLatestPostsBlock.tsx
+++ b/react/components/WordpressLatestPostsBlock.tsx
@@ -25,6 +25,7 @@ const WordpressLatestPostsBlock: StorefrontFunctionComponent<WPLatestPostsBlockP
   showDates,
   showAuthors,
   showExcerpts,
+  subcategoryUrls,
   absoluteLinks,
   numberOfPosts,
   customDomain,
@@ -62,13 +63,8 @@ const WordpressLatestPostsBlock: StorefrontFunctionComponent<WPLatestPostsBlockP
                     customDomainSlug={customDomainSlug}
                     author={data.wpPosts.posts[0].author?.name ?? ''}
                     excerpt={data.wpPosts.posts[0].excerpt.rendered}
-                    category={data.wpPosts.posts[0].categories[0]?.name ?? ''}
-                    categoryId={
-                      data.wpPosts.posts[0].categories[0]?.id ?? undefined
-                    }
-                    categorySlug={
-                      data.wpPosts.posts[0].categories[0]?.slug ?? ''
-                    }
+                    categories={data.wpPosts.posts[0].categories}
+                    subcategoryUrls={subcategoryUrls}
                     image={
                       data.wpPosts.posts[0].featured_media?.source_url ?? ''
                     }
@@ -105,9 +101,8 @@ const WordpressLatestPostsBlock: StorefrontFunctionComponent<WPLatestPostsBlockP
                           customDomainSlug={customDomainSlug}
                           author={post.author ? post.author.name : ''}
                           excerpt={post.excerpt.rendered}
-                          category={post.categories[0]?.name ?? ''}
-                          categoryId={post.categories[0]?.id ?? undefined}
-                          categorySlug={post.categories[0]?.slug ?? ''}
+                          categories={data.wpPosts.posts[0].categories}
+                          subcategoryUrls={subcategoryUrls}
                           image={post.featured_media?.source_url ?? ''}
                           altText={post.featured_media?.alt_text ?? ''}
                           mediaType={post.featured_media?.media_type ?? ''}
@@ -137,9 +132,8 @@ const WordpressLatestPostsBlock: StorefrontFunctionComponent<WPLatestPostsBlockP
                     customDomainSlug={customDomainSlug}
                     author={post.author?.name ?? ''}
                     excerpt={post.excerpt.rendered}
-                    category={post.categories[0]?.name ?? ''}
-                    categoryId={post.categories[0]?.id ?? undefined}
-                    categorySlug={post.categories[0]?.slug ?? ''}
+                    categories={data.wpPosts.posts[0].categories}
+                    subcategoryUrls={subcategoryUrls}
                     image={post.featured_media?.source_url ?? ''}
                     altText={post.featured_media?.alt_text ?? ''}
                     mediaType={post.featured_media?.media_type ?? ''}
@@ -176,6 +170,7 @@ interface WPLatestPostsBlockProps {
   showDates: boolean
   showAuthors: boolean
   showExcerpts: boolean
+  subcategoryUrls: boolean
   absoluteLinks: boolean
   customDomain: string
   customDomainSlug: string
@@ -191,6 +186,7 @@ WordpressLatestPostsBlock.defaultProps = {
   showAuthors: false,
   showExcerpts: false,
   customDomain: undefined,
+  subcategoryUrls: false,
   absoluteLinks: false,
   customDomainSlug: undefined,
 }
@@ -292,6 +288,14 @@ const messages = defineMessages({
     defaultMessage: '',
     id: 'admin/editor.wordpressCustomDomainSlug.description',
   },
+  subcategoryUrlsTitle: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.title',
+  },
+  subcategoryUrlsDescription: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.description',
+  },
 })
 
 WordpressLatestPostsBlock.schema = {
@@ -373,6 +377,13 @@ WordpressLatestPostsBlock.schema = {
       title: messages.customDomainSlugTitle.id,
       description: messages.customDomainSlugDescription.id,
       type: 'string',
+      isLayout: false,
+      default: '',
+    },
+    subcategoryUrls: {
+      title: messages.subcategoryUrlsTitle.id,
+      description: messages.subcategoryUrlsDescription.id,
+      type: 'boolean',
       isLayout: false,
       default: '',
     },

--- a/react/components/WordpressPage.tsx
+++ b/react/components/WordpressPage.tsx
@@ -115,6 +115,8 @@ const CSS_HANDLES = [
   'postContainer',
   'postTitle',
   'postMeta',
+  'postMetaDate',
+  'postMetaAuthor',
   'postFeaturedImage',
   'postFeaturedImageContainer',
   'postBody',
@@ -205,7 +207,7 @@ const WordpressPageInner: FunctionComponent<{ pageData: any }> = props => {
           dangerouslySetInnerHTML={{ __html: titleHtml }}
         />
         <p className={`${handles.postMeta} t-small mw9 c-muted-1`}>
-          <span>
+          <span className={`${handles.postMetaDate}`}>
             <FormattedMessage
               id="store/wordpress-integration.wordpressPage.posted"
               defaultMessage="Posted {formattedDate} "
@@ -215,7 +217,7 @@ const WordpressPageInner: FunctionComponent<{ pageData: any }> = props => {
             />
           </span>
           {author && (
-            <span>
+            <span className={`${handles.postMetaAuthor}`}>
               <FormattedMessage
                 id="store/wordpress-integration.wordpressPage.byAuthor"
                 defaultMessage=" by {name}"

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -20,6 +20,7 @@ interface Props {
   searchQuery: any
   customDomain: string
   customDomainSlug: string
+  subcategoryUrls: boolean
   postsPerPage: number
 }
 
@@ -38,6 +39,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
   searchQuery,
   customDomain,
   customDomainSlug,
+  subcategoryUrls,
   postsPerPage,
 }) => {
   const [page, setPage] = useState(1)
@@ -176,9 +178,8 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
                   <WordpressTeaser
                     title={post.title.rendered}
                     author={post.author.name}
-                    category={post.categories[0]?.name ?? ''}
-                    categoryId={post.categories[0]?.id ?? undefined}
-                    categorySlug={post.categories[0]?.slug ?? ''}
+                    categories={post.categories}
+                    subcategoryUrls={subcategoryUrls}
                     customDomainSlug={customDomainSlug}
                     excerpt={post.excerpt.rendered}
                     date={post.date}
@@ -235,11 +236,20 @@ const messages = defineMessages({
     defaultMessage: '',
     id: 'admin/editor.wordpressCustomDomainSlug.description',
   },
+  subcategoryUrlsTitle: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.title',
+  },
+  subcategoryUrlsDescription: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.description',
+  },
 })
 
 WordpressSearchResult.defaultProps = {
   customDomain: undefined,
   customDomainSlug: undefined,
+  subcategoryUrls: false,
   postsPerPage: 10,
 }
 
@@ -259,6 +269,13 @@ WordpressSearchResult.schema = {
       title: messages.customDomainSlugTitle.id,
       description: messages.customDomainSlugDescription.id,
       type: 'string',
+      isLayout: false,
+      default: '',
+    },
+    subcategoryUrls: {
+      title: messages.subcategoryUrlsTitle.id,
+      description: messages.subcategoryUrlsDescription.id,
+      type: 'boolean',
       isLayout: false,
       default: '',
     },

--- a/react/components/WordpressRelatedPostsBlock.tsx
+++ b/react/components/WordpressRelatedPostsBlock.tsx
@@ -22,6 +22,7 @@ const WordpressRelatedPostsBlock: StorefrontFunctionComponent<WPRelatedPostsBloc
   showDates,
   showAuthors,
   showExcerpts,
+  subcategoryUrls,
   absoluteLinks,
   numberOfPosts,
   customDomain,
@@ -65,9 +66,8 @@ const WordpressRelatedPostsBlock: StorefrontFunctionComponent<WPRelatedPostsBloc
                     link={post.link}
                     author={post.author ? post.author.name : ''}
                     excerpt={post.excerpt.rendered}
-                    category={post.categories[0]?.name ?? ''}
-                    categoryId={post.categories[0]?.id ?? undefined}
-                    categorySlug={post.categories[0]?.slug ?? ''}
+                    categories={post.categories}
+                    subcategoryUrls={subcategoryUrls}
                     customDomainSlug={customDomainSlug}
                     image={post.featured_media?.source_url ?? ''}
                     altText={post.featured_media?.alt_text ?? ''}
@@ -99,6 +99,7 @@ interface WPRelatedPostsBlockProps {
   showDates: boolean
   showAuthors: boolean
   showExcerpts: boolean
+  subcategoryUrls: boolean
   absoluteLinks: boolean
   productQuery: ProductQuery
   customDomain: string
@@ -169,6 +170,7 @@ WordpressRelatedPostsBlock.defaultProps = {
   showDates: true,
   showAuthors: false,
   showExcerpts: false,
+  subcategoryUrls: false,
   absoluteLinks: false,
   customDomain: undefined,
   customDomainSlug: undefined,
@@ -263,6 +265,14 @@ const messages = defineMessages({
     defaultMessage: '',
     id: 'admin/editor.wordpressCustomDomainSlug.description',
   },
+  subcategoryUrlsTitle: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.title',
+  },
+  subcategoryUrlsDescription: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.description',
+  },
 })
 
 WordpressRelatedPostsBlock.schema = {
@@ -337,6 +347,13 @@ WordpressRelatedPostsBlock.schema = {
       title: messages.customDomainSlugTitle.id,
       description: messages.customDomainSlugDescription.id,
       type: 'string',
+      isLayout: false,
+      default: '',
+    },
+    subcategoryUrls: {
+      title: messages.subcategoryUrlsTitle.id,
+      description: messages.subcategoryUrlsDescription.id,
+      type: 'boolean',
       isLayout: false,
       default: '',
     },

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -20,6 +20,7 @@ import Settings from '../graphql/Settings.graphql'
 
 interface SearchProps {
   customDomains: string
+  subcategoryUrls: boolean
   postsPerPage: number
 }
 
@@ -36,6 +37,7 @@ const CSS_HANDLES = [
 
 const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
   customDomains,
+  subcategoryUrls,
   postsPerPage,
 }) => {
   const {
@@ -237,9 +239,8 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
                   <WordpressTeaser
                     title={post.title.rendered}
                     author={post.author.name}
-                    category={post.categories[0]?.name ?? ''}
-                    categoryId={post.categories[0]?.id ?? undefined}
-                    categorySlug={post.categories[0]?.slug ?? ''}
+                    categories={post.categories}
+                    subcategoryUrls={subcategoryUrls}
                     customDomainSlug={params.customdomainslug}
                     excerpt={post.excerpt.rendered}
                     date={post.date}
@@ -288,10 +289,19 @@ const messages = defineMessages({
     defaultMessage: '',
     id: 'admin/editor.wordpressCustomDomains.description',
   },
+  subcategoryUrlsTitle: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.title',
+  },
+  subcategoryUrlsDescription: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.description',
+  },
 })
 
 WordpressSearchResult.defaultProps = {
   customDomains: undefined,
+  subcategoryUrls: false,
   postsPerPage: 10,
 }
 
@@ -304,6 +314,13 @@ WordpressSearchResult.schema = {
       title: messages.customDomainsTitle.id,
       description: messages.customDomainsDescription.id,
       type: 'string',
+      isLayout: false,
+      default: '',
+    },
+    subcategoryUrls: {
+      title: messages.subcategoryUrlsTitle.id,
+      description: messages.subcategoryUrlsDescription.id,
+      type: 'boolean',
       isLayout: false,
       default: '',
     },

--- a/react/components/WordpressSearchResultBlock.tsx
+++ b/react/components/WordpressSearchResultBlock.tsx
@@ -24,6 +24,7 @@ const WordpressSearchResultBlock: StorefrontFunctionComponent<WPSearchResultBloc
   showDates,
   showAuthors,
   showExcerpts,
+  subcategoryUrls,
   absoluteLinks,
   numberOfPosts,
   customDomain,
@@ -66,9 +67,8 @@ const WordpressSearchResultBlock: StorefrontFunctionComponent<WPSearchResultBloc
                   customDomainSlug={customDomainSlug}
                   author={post.author?.name ?? ''}
                   excerpt={post.excerpt.rendered}
-                  category={post.categories[0]?.name ?? ''}
-                  categoryId={post.categories[0]?.id ?? undefined}
-                  categorySlug={post.categories[0]?.slug ?? ''}
+                  categories={post.categories}
+                  subcategoryUrls={subcategoryUrls}
                   image={post.featured_media?.source_url ?? ''}
                   altText={post.featured_media?.alt_text ?? ''}
                   mediaType={post.featured_media?.media_type ?? ''}
@@ -113,6 +113,7 @@ interface WPSearchResultBlockProps {
   showDates: boolean
   showAuthors: boolean
   showExcerpts: boolean
+  subcategoryUrls: boolean
   absoluteLinks: boolean
   searchQuery: any
   customDomain: string
@@ -126,6 +127,7 @@ WordpressSearchResultBlock.defaultProps = {
   showDates: true,
   showAuthors: false,
   showExcerpts: false,
+  subcategoryUrls: false,
   absoluteLinks: false,
   customDomain: undefined,
   customDomainSlug: undefined,
@@ -212,6 +214,14 @@ const messages = defineMessages({
     defaultMessage: '',
     id: 'admin/editor.wordpressCustomDomainSlug.description',
   },
+  subcategoryUrlsTitle: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.title',
+  },
+  subcategoryUrlsDescription: {
+    defaultMessage: '',
+    id: 'admin/editor.wordpressSubcategoryUrls.description',
+  },
 })
 
 WordpressSearchResultBlock.schema = {
@@ -279,6 +289,13 @@ WordpressSearchResultBlock.schema = {
       title: messages.customDomainSlugTitle.id,
       description: messages.customDomainSlugDescription.id,
       type: 'string',
+      isLayout: false,
+      default: '',
+    },
+    subcategoryUrls: {
+      title: messages.subcategoryUrlsTitle.id,
+      description: messages.subcategoryUrlsDescription.id,
+      type: 'boolean',
       isLayout: false,
       default: '',
     },

--- a/react/components/WordpressTeaser.tsx
+++ b/react/components/WordpressTeaser.tsx
@@ -4,13 +4,14 @@ import { Link, useRuntime } from 'vtex.render-runtime'
 import insane from 'insane'
 import { useCssHandles } from 'vtex.css-handles'
 
+import linkParams from '../utils/categoryLinkParams'
+
 interface TeaserProps {
   title: string
   author: string
   excerpt: string
-  category?: string
-  categoryId?: number
-  categorySlug?: string
+  categories?: WPCategory[]
+  subcategoryUrls?: boolean
   customDomainSlug?: string
   date: string
   id: number
@@ -55,8 +56,8 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
   title,
   author,
   excerpt,
-  category,
-  categorySlug,
+  categories,
+  subcategoryUrls,
   customDomainSlug,
   date,
   slug,
@@ -85,228 +86,245 @@ const WordpressTeaser: FunctionComponent<TeaserProps> = ({
   const sanitizedExcerpt = useMemo(() => {
     return insane(excerpt, sanitizerConfigStripAll)
   }, [excerpt, sanitizerConfigStripAll])
+
+  const category = categories?.length && categories?.find(c => c.parent === 0)
+  const subcategory =
+    subcategoryUrls && category
+      ? categories?.find(sub => sub.parent === category.id)
+      : undefined
+
   return (
-    <Card noPadding className={`${handles.teaserContainer}`}>
-      {(showCategory || showDate || showAuthor) &&
-        (!useTextOverlay || mediaType !== 'image') && (
-          <h5 className={`${handles.teaserHeader} mv1 ph6 pt6 pb4`}>
-            {showCategory && category && categorySlug && (
-              <Fragment>
-                <Link
-                  page="store.blog-category"
-                  params={{
-                    categoryslug: categorySlug,
-                    categoryslug_id: categorySlug,
-                    customdomainslug: customDomainSlug,
-                  }}
-                  className={`${handles.teaserCategoryLink}`}
-                >
-                  {category}
-                </Link>
-              </Fragment>
-            )}
-            {((showCategory && showDate) || (showCategory && showAuthor)) && (
-              <span className={`${handles.teaserSeparator}`}> - </span>
-            )}
-            {showDate && (
-              <span className={`${handles.teaserDate}`}>{formattedDate}</span>
-            )}
-            {showDate && showAuthor && (
-              <span className={`${handles.teaserSeparator}`}> - </span>
-            )}
-            {showAuthor && (
-              <span className={`${handles.teaserAuthor}`}>{author}</span>
-            )}
-          </h5>
-        )}
-      {mediaType === 'image' && (
-        <Fragment>
-          {useTextOverlay ? (
-            <div className="tc-m db relative">
-              <img
-                className={`${handles.teaserImage} w-100`}
-                src={image}
-                alt={altText}
-              ></img>
-              <div
-                className={`${handles.teaserGradientOverlay} absolute absolute--fill`}
-                style={{
-                  background: `linear-gradient(to bottom,rgba(0,0,0,0) 0,rgba(0,0,0,0) 50%,rgba(0,0,0,.6) 100%)`,
-                }}
-              >
+    <div className={`${handles.teaserContainer}`}>
+      <Card noPadding>
+        {(showCategory || showDate || showAuthor) &&
+          (!useTextOverlay || mediaType !== 'image') && (
+            <h5 className={`${handles.teaserHeader} mv1 ph6 pt6 pb4`}>
+              {showCategory && category && (
+                <Fragment>
+                  <Link
+                    page={
+                      subcategory
+                        ? 'store.blog-category#subcategory'
+                        : 'store.blog-category'
+                    }
+                    params={linkParams(customDomainSlug, category, subcategory)}
+                    className={`${handles.teaserCategoryLink}`}
+                  >
+                    {subcategory ? subcategory.name : category.name}
+                  </Link>
+                </Fragment>
+              )}
+              {((showCategory && showDate) || (showCategory && showAuthor)) && (
+                <span className={`${handles.teaserSeparator}`}> - </span>
+              )}
+              {showDate && (
+                <span className={`${handles.teaserDate}`}>{formattedDate}</span>
+              )}
+              {showDate && showAuthor && (
+                <span className={`${handles.teaserSeparator}`}> - </span>
+              )}
+              {showAuthor && (
+                <span className={`${handles.teaserAuthor}`}>{author}</span>
+              )}
+            </h5>
+          )}
+        {mediaType === 'image' && (
+          <Fragment>
+            {useTextOverlay ? (
+              <div className="tc-m db relative">
+                <img
+                  className={`${handles.teaserImage} w-100`}
+                  src={image}
+                  alt={altText}
+                ></img>
                 <div
-                  className={`${handles.teaserTextOverlay} absolute tl`}
+                  className={`${handles.teaserGradientOverlay} absolute absolute--fill`}
                   style={{
-                    bottom: `15%`,
-                    left: `5%`,
+                    background: `linear-gradient(to bottom,rgba(0,0,0,0) 0,rgba(0,0,0,0) 50%,rgba(0,0,0,.6) 100%)`,
                   }}
                 >
                   <div
-                    className={`${handles.teaserTextOverlayTitle} t-heading-5 white fw5 mb3`}
+                    className={`${handles.teaserTextOverlay} absolute tl`}
+                    style={{
+                      bottom: `15%`,
+                      left: `5%`,
+                    }}
                   >
-                    {absoluteLinks ? (
-                      <Link
-                        to={link}
-                        target="_blank"
-                        className="white no-underline"
-                      >
-                        {title}
-                      </Link>
-                    ) : (
-                      <Link
-                        page="store.blog-post"
-                        params={{
-                          slug,
-                          slug_id: slug,
-                          customdomainslug: customDomainSlug,
-                        }}
-                        className="white no-underline"
-                      >
-                        {title}
-                      </Link>
-                    )}
-                  </div>
-                  {(showCategory || showDate || showAuthor) && (
                     <div
-                      className={`${handles.teaserTextOverlayMeta} white t-mini`}
+                      className={`${handles.teaserTextOverlayTitle} t-heading-5 white fw5 mb3`}
                     >
-                      {showCategory && category && categorySlug && (
-                        <Fragment>
-                          <Link
-                            page="store.blog-category"
-                            params={{
-                              categoryslug: categorySlug,
-                              categoryslug_id: categorySlug,
-                              customdomainslug: customDomainSlug,
-                            }}
-                            className={`${handles.teaserCategoryLink} white`}
-                          >
-                            {category}
-                          </Link>
-                        </Fragment>
-                      )}
-                      {((showCategory && showDate) ||
-                        (showCategory && showAuthor)) && (
-                        <span className={`${handles.teaserSeparator}`}>
-                          {' '}
-                          -{' '}
-                        </span>
-                      )}
-                      {showDate && (
-                        <span className={`${handles.teaserDate}`}>
-                          {formattedDate}
-                        </span>
-                      )}
-                      {showDate && showAuthor && (
-                        <span className={`${handles.teaserSeparator}`}>
-                          {' '}
-                          -{' '}
-                        </span>
-                      )}
-                      {showAuthor && (
-                        <span className={`${handles.teaserAuthor}`}>
-                          {author}
-                        </span>
+                      {absoluteLinks ? (
+                        <Link
+                          to={link}
+                          target="_blank"
+                          className="white no-underline"
+                        >
+                          {title}
+                        </Link>
+                      ) : (
+                        <Link
+                          page="store.blog-post"
+                          params={{
+                            slug,
+                            slug_id: slug,
+                            customdomainslug: customDomainSlug,
+                          }}
+                          className="white no-underline"
+                        >
+                          {title}
+                        </Link>
                       )}
                     </div>
-                  )}
+                    {(showCategory || showDate || showAuthor) && (
+                      <div
+                        className={`${handles.teaserTextOverlayMeta} white t-mini`}
+                      >
+                        {showCategory && category && (
+                          <Fragment>
+                            <Link
+                              page={
+                                subcategoryUrls
+                                  ? 'store.blog-category#subcategory'
+                                  : 'store.blog-category'
+                              }
+                              params={linkParams(
+                                customDomainSlug,
+                                category,
+                                subcategory
+                              )}
+                              className={`${handles.teaserCategoryLink} white`}
+                            >
+                              {subcategory ? subcategory.name : category.name}
+                            </Link>
+                          </Fragment>
+                        )}
+                        {((showCategory && showDate) ||
+                          (showCategory && showAuthor)) && (
+                          <span className={`${handles.teaserSeparator}`}>
+                            {' '}
+                            -{' '}
+                          </span>
+                        )}
+                        {showDate && (
+                          <span className={`${handles.teaserDate}`}>
+                            {formattedDate}
+                          </span>
+                        )}
+                        {showDate && showAuthor && (
+                          <span className={`${handles.teaserSeparator}`}>
+                            {' '}
+                            -{' '}
+                          </span>
+                        )}
+                        {showAuthor && (
+                          <span className={`${handles.teaserAuthor}`}>
+                            {author}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 </div>
               </div>
-            </div>
-          ) : (
-            <Fragment>
-              {absoluteLinks ? (
-                <Link to={link} target="_blank" className={`${handles.teaserImageContainer} tc-m db`}>
-                  <img
-                    className={`${handles.teaserImage}`}
-                    src={image}
-                    alt={altText}
-                  ></img>
-                </Link>
-              ) : (
-                <Link
-                  page="store.blog-post"
-                  params={{
-                    slug,
-                    slug_id: slug,
-                    customdomainslug: customDomainSlug,
-                  }}
-                  className={`${handles.teaserImageContainer} tc-m db`}
-                >
-                  <img
-                    className={`${handles.teaserImage}`}
-                    src={image}
-                    alt={altText}
-                  ></img>
-                </Link>
-              )}
-              <h3
-                className={`${handles.teaserTitle} t-heading-3 mv0 pt4 pb6 ph6`}
-              >
+            ) : (
+              <Fragment>
                 {absoluteLinks ? (
                   <Link
-                    className={`${handles.teaserTitleLink}`}
                     to={link}
                     target="_blank"
+                    className={`${handles.teaserImageContainer} tc-m db`}
                   >
-                    <span
-                      dangerouslySetInnerHTML={{ __html: sanitizedTitle }}
-                    />
+                    <img
+                      className={`${handles.teaserImage}`}
+                      src={image}
+                      alt={altText}
+                    ></img>
                   </Link>
                 ) : (
                   <Link
-                    className={`${handles.teaserTitleLink}`}
                     page="store.blog-post"
                     params={{
                       slug,
                       slug_id: slug,
                       customdomainslug: customDomainSlug,
                     }}
+                    className={`${handles.teaserImageContainer} tc-m db`}
                   >
-                    <span
-                      dangerouslySetInnerHTML={{ __html: sanitizedTitle }}
-                    />
+                    <img
+                      className={`${handles.teaserImage}`}
+                      src={image}
+                      alt={altText}
+                    ></img>
                   </Link>
                 )}
-              </h3>
-            </Fragment>
-          )}
-        </Fragment>
-      )}
+                <h3
+                  className={`${handles.teaserTitle} t-heading-3 mv0 pt4 pb6 ph6`}
+                >
+                  {absoluteLinks ? (
+                    <Link
+                      className={`${handles.teaserTitleLink}`}
+                      to={link}
+                      target="_blank"
+                    >
+                      <span
+                        dangerouslySetInnerHTML={{ __html: sanitizedTitle }}
+                      />
+                    </Link>
+                  ) : (
+                    <Link
+                      className={`${handles.teaserTitleLink}`}
+                      page="store.blog-post"
+                      params={{
+                        slug,
+                        slug_id: slug,
+                        customdomainslug: customDomainSlug,
+                      }}
+                    >
+                      <span
+                        dangerouslySetInnerHTML={{ __html: sanitizedTitle }}
+                      />
+                    </Link>
+                  )}
+                </h3>
+              </Fragment>
+            )}
+          </Fragment>
+        )}
 
-      {mediaType !== 'image' && (
-        <h3 className={`${handles.teaserTitle} t-heading-3 mv0 pt4 pb6 ph6`}>
-          {absoluteLinks ? (
-            <Link
-              className={`${handles.teaserTitleLink}`}
-              to={link}
-              target="_blank"
-            >
-              <span dangerouslySetInnerHTML={{ __html: sanitizedTitle }} />
-            </Link>
-          ) : (
-            <Link
-              className={`${handles.teaserTitleLink}`}
-              page="store.blog-post"
-              params={{
-                slug,
-                slug_id: slug,
-                customdomainslug: customDomainSlug,
-              }}
-            >
-              <span dangerouslySetInnerHTML={{ __html: sanitizedTitle }} />
-            </Link>
-          )}
-        </h3>
-      )}
+        {mediaType !== 'image' && (
+          <h3 className={`${handles.teaserTitle} t-heading-3 mv0 pt4 pb6 ph6`}>
+            {absoluteLinks ? (
+              <Link
+                className={`${handles.teaserTitleLink}`}
+                to={link}
+                target="_blank"
+              >
+                <span dangerouslySetInnerHTML={{ __html: sanitizedTitle }} />
+              </Link>
+            ) : (
+              <Link
+                className={`${handles.teaserTitleLink}`}
+                page="store.blog-post"
+                params={{
+                  slug,
+                  slug_id: slug,
+                  customdomainslug: customDomainSlug,
+                }}
+              >
+                <span dangerouslySetInnerHTML={{ __html: sanitizedTitle }} />
+              </Link>
+            )}
+          </h3>
+        )}
 
-      {showExcerpt && (
-        <div
-          className={`${handles.teaserBody} ph6 pb6`}
-          dangerouslySetInnerHTML={{ __html: sanitizedExcerpt }}
-        />
-      )}
-    </Card>
+        {showExcerpt && (
+          <div
+            className={`${handles.teaserBody} ph6 pb6`}
+            dangerouslySetInnerHTML={{ __html: sanitizedExcerpt }}
+          />
+        )}
+      </Card>
+    </div>
   )
 }
 

--- a/react/contexts/WordpressRelatedProducts.tsx
+++ b/react/contexts/WordpressRelatedProducts.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 interface WPRelatedProductsContextInterface {
-  productIds: [string?]
+  productIds?: string[]
 }
 
 export const WPRelatedProductsContext = React.createContext<

--- a/react/graphql/AllPosts.graphql
+++ b/react/graphql/AllPosts.graphql
@@ -13,6 +13,7 @@ query AllPosts($wp_page: Int, $wp_per_page: Int, $customDomain: String) {
       categories(customDomain: $customDomain) {
         name
         id
+        parent
         slug
       }
       featured_media(customDomain: $customDomain) {

--- a/react/graphql/CategoryPosts.graphql
+++ b/react/graphql/CategoryPosts.graphql
@@ -25,6 +25,7 @@ query CategoryPosts(
         categories(customDomain: $customDomain) {
           name
           id
+          parent
           slug
         }
         featured_media(customDomain: $customDomain) {

--- a/react/graphql/CategoryPostsBySlug.graphql
+++ b/react/graphql/CategoryPostsBySlug.graphql
@@ -26,6 +26,7 @@ query CategoryPostsBySlug(
           categories(customDomain: $customDomain) {
             name
             id
+            parent
             slug
           }
           featured_media(customDomain: $customDomain) {

--- a/react/graphql/PostSimpleBySlug.graphql
+++ b/react/graphql/PostSimpleBySlug.graphql
@@ -7,6 +7,7 @@ query PostSimpleBySlug($slug: String!, $customDomain: String) {
       categories(customDomain: $customDomain) {
         name
         id
+        parent
         slug
       }
     }

--- a/react/graphql/SinglePostBySlug.graphql
+++ b/react/graphql/SinglePostBySlug.graphql
@@ -16,6 +16,7 @@ query SinglePostBySlug($slug: String!, $customDomain: String) {
       categories(customDomain: $customDomain) {
         name
         id
+        parent
         slug
       }
       date

--- a/react/package.json
+++ b/react/package.json
@@ -38,9 +38,9 @@
     "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.43.0/public/@types/vtex.search-graphql",
     "vtex.search-page-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-page-context@0.2.0/public/@types/vtex.search-page-context",
     "vtex.shelf": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shelf@1.44.2/public/_types/react",
-    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.116.0/public/@types/vtex.store",
-    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.143.1/public/@types/vtex.store-components",
-    "vtex.store-sitemap": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.8/public/@types/vtex.store-sitemap",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.140.0/public/@types/vtex.styleguide"
+    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.117.0/public/@types/vtex.store",
+    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.144.0/public/@types/vtex.store-components",
+    "vtex.store-sitemap": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.9/public/@types/vtex.store-sitemap",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.142.0/public/@types/vtex.styleguide"
   }
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -6,7 +6,7 @@ interface Window extends Window {
   }
 }
 
-type PostData = {
+interface PostData {
   title: WPTitle
   author: WPUser
   content: WPContent
@@ -19,16 +19,17 @@ type PostData = {
   featured_media: WPMedia
   tags: [WPTag]
 }
-type WPTitle = {
+
+interface WPTitle {
   raw: string
   rendered: string
 }
-type WPContent = {
+interface WPContent {
   raw: string
   rendered: string
   protected: bool
 }
-type WPUser = {
+interface WPUser {
   id: number
   username: string
   name: string
@@ -49,7 +50,7 @@ type WPUser = {
   avatar_urls: WPAvatarObject
   meta: string
 }
-type WPCategory = {
+interface WPCategory {
   id: number
   slug: string
   count: number
@@ -60,7 +61,7 @@ type WPCategory = {
   parent: number
   meta: string
 }
-type WPExcerpt = {
+interface WPExcerpt {
   raw: string
   rendered: string
   protected: bool
@@ -72,12 +73,12 @@ enum WPTaxonomyType {
   link_category,
   post_format,
 }
-type WPAvatarObject = {
+interface WPAvatarObject {
   size24: string
   size48: string
   size96: string
 }
-type WPMedia = {
+interface WPMedia {
   date: string
   date_gmt: string
   guid: WPGuid
@@ -103,14 +104,14 @@ type WPMedia = {
   post: number
   source_url: string
 }
-type WPMediaDetails = {
+interface WPMediaDetails {
   file: string
   height: number
   image_meta: WPImageMeta
   sizes: [WPMediaSize]
   width: number
 }
-type WPImageMeta = {
+interface WPImageMeta {
   aperture: string
   camera: string
   caption: string
@@ -124,7 +125,7 @@ type WPImageMeta = {
   shutter_speed: string
   title: string
 }
-type WPMediaSize = {
+interface WPMediaSize {
   file: string
   height: number
   mime_type: string
@@ -132,7 +133,7 @@ type WPMediaSize = {
   source_url: string
   width: number
 }
-type WPContentDescriptor = {
+interface WPContentDescriptor {
   raw: string
   rendered: string
   protected: bool
@@ -141,7 +142,7 @@ enum WPOpenClosed {
   open,
   closed,
 }
-type WPGuid = {
+interface WPGuid {
   raw: string
   rendered: string
 }
@@ -152,7 +153,7 @@ enum WPStatus {
   pending,
   private,
 }
-type WPTag = {
+interface WPTag {
   id: number
   count: number
   description: string

--- a/react/utils/categoryLinkParams.ts
+++ b/react/utils/categoryLinkParams.ts
@@ -1,0 +1,21 @@
+const linkParams = (
+  customDomainSlug: string | undefined,
+  category: WPCategory,
+  subcategory: WPCategory | undefined = undefined
+) => {
+  if (subcategory) {
+    return {
+      categoryslug: category.slug,
+      subcategoryslug_id: subcategory.slug,
+      customdomainslug: customDomainSlug,
+    }
+  }
+
+  return {
+    categoryslug: category.slug,
+    categoryslug_id: category.slug,
+    customdomainslug: customDomainSlug,
+  }
+}
+
+export default linkParams

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -530,21 +530,21 @@ typescript@3.9.7:
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shelf@1.44.2/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.143.1/public/@types/vtex.store-components":
-  version "3.143.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.143.1/public/@types/vtex.store-components#e3ea200b8975e7e4631b625378b051e0e582d181"
+"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.144.0/public/@types/vtex.store-components":
+  version "3.144.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.144.0/public/@types/vtex.store-components#7731a0fb7cec831b93b5037c6f694205eb34a247"
 
-"vtex.store-sitemap@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.8/public/@types/vtex.store-sitemap":
-  version "2.13.8"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.8/public/@types/vtex.store-sitemap#b5c9a6d29d74d8deaab9a5c4f95d909fd94cc325"
+"vtex.store-sitemap@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.9/public/@types/vtex.store-sitemap":
+  version "2.13.9"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.9/public/@types/vtex.store-sitemap#88060df3db5dedfa04e15f37a331340780822001"
 
-"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.116.0/public/@types/vtex.store":
-  version "2.116.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.116.0/public/@types/vtex.store#ed1aaedd39b07a8e99b5bd303e5fdc45cb815a1d"
+"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.117.0/public/@types/vtex.store":
+  version "2.117.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.117.0/public/@types/vtex.store#9f7403d597b8927af64b520f4de62bda34dad3ab"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.140.0/public/@types/vtex.styleguide":
-  version "9.140.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.140.0/public/@types/vtex.styleguide#f3180d1ff13a4d93be89505740ca5527c6e12313"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.142.0/public/@types/vtex.styleguide":
+  version "9.142.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.142.0/public/@types/vtex.styleguide#12d22690aa1896a7516eb4b7bc8923216aed7725"
 
 zen-observable-ts@^0.8.21:
   version "0.8.21"


### PR DESCRIPTION
**What problem is this solving?**

Adds the option to include a subcategory in the blog URLs, `/blog/category/subcategory`. This can improve user navigation within the blog content and improve SEO.   

Includes a container `div` around the Teaser component, as well as some additional CSS handles
```
postMetaDate
postMetaAuthor
postMetaCategory
```

**How should this be manually tested?**

[workspace with subcategory URLs enabled](https://wpsubcategory--arcaplanet.myvtex.com)
[workspace without subcategory URLs enabled](https://wpcategory--arcaplanet.myvtex.com)

**Screenshots or example usage:**

![Screenshot from 2021-06-04 09-27-05](https://user-images.githubusercontent.com/22715037/120808531-27f1a680-c517-11eb-99a2-3555addb13dc.png)
