### PR TITLE
Add support for Yoast SEO plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add support for Yoast SEO plugin
+
 ## [2.9.0] - 2021-06-11
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -363,6 +363,12 @@ For example:
 },
 ```
 
+## WordPress Plugins Support
+
+### Yoast SEO
+
+The [Yoast SEO plugin](https://yoast.com/wordpress/plugins/seo/) provides meta tags and structured data for your WordPress content. If your WordPress installation has this plugin, the app will include this data on your posts or pages.
+
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -18,6 +18,7 @@ type WPPost {
   ping_status: WPOpenClosed
   format: WPFormat
   meta: String
+  headerTags: HeaderTags
   sticky: Boolean
   template: String
   categories(customDomain: String): [WPCategory]
@@ -510,6 +511,17 @@ type WPUsersResult {
 type Settings {
   titleTag: String
   blogRoute: String
+}
+
+type HeaderTags {
+  metaTags: [MetaTag]
+  ldJson: String
+}
+
+type MetaTag {
+  name: String
+  property: String
+  content: String
 }
 
 type Query {

--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
     "@types/he": "^1.1.0",
     "@types/jsdom": "^16.2.10",
     "@types/sanitize-html": "^1.20.2",
-    "@vtex/api": "6.42.1",
+    "@vtex/api": "6.43.0",
     "vtex.blog-interfaces": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.blog-interfaces@0.2.0/public/@types/vtex.blog-interfaces",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.9/public/@types/vtex.product-context",

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -316,6 +316,7 @@ export const queries = {
     const pages = data
     if (data.length) {
       pages[0].content.rendered = addCSShandles(data[0].content.rendered)
+      pages[0].headerTags = addHeaderTags(data[0])
     }
     const total_count = headers['x-wp-total']
     const result = { pages, total_count }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,6 +1,6 @@
 import { LogLevel } from '@vtex/api'
 
-import addCSShandles from '../utils/jsdom'
+import { addCSShandles, addHeaderTags } from '../utils/jsdom'
 
 /* eslint-disable @typescript-eslint/camelcase */
 export const queries = {
@@ -92,6 +92,7 @@ export const queries = {
     const posts = data
     if (data.length) {
       posts[0].content.rendered = addCSShandles(data[0].content.rendered)
+      posts[0].headerTags = addHeaderTags(data[0])
     }
     const total_count = headers['x-wp-total']
     const result = { posts, total_count }

--- a/node/typings/wordpress.d.ts
+++ b/node/typings/wordpress.d.ts
@@ -9,7 +9,7 @@ interface WpPost {
   status: 'publish'
   type: 'post'
   link: string
-  title: any
+  title: Title
   content: Content
   excerpt: any
   author: number
@@ -22,7 +22,14 @@ interface WpPost {
   meta: string[]
   categories: string[]
   tags: string[]
+  yoast_head?: string
+  headerTags?: HeaderTags | null
   _links: any
+}
+
+interface Title {
+  rendered: string
+  protected: boolean
 }
 
 interface Content {
@@ -47,4 +54,15 @@ interface WpCategory extends WpTag {
 
 interface Meta {
   [key: string]: string
+}
+
+interface HeaderTags {
+  metaTags: MetaTag[]
+  ldJson: string
+}
+
+interface MetaTag {
+  name: string
+  property: string
+  content: string
 }

--- a/node/utils/jsdom.ts
+++ b/node/utils/jsdom.ts
@@ -2,7 +2,7 @@ import jsdom from 'jsdom'
 
 const { JSDOM } = jsdom
 
-const addCSShandles = (content: string) => {
+export const addCSShandles = (content: string) => {
   // A cached version of content may already contain the CSS handles
   if (content.includes('vtex-wordpress-integration')) {
     return content
@@ -29,4 +29,29 @@ const addCSShandles = (content: string) => {
   return document.body.innerHTML
 }
 
-export default addCSShandles
+export const addHeaderTags = (post: WpPost): HeaderTags | null => {
+  if (!post.yoast_head) return null
+
+  const dom = new JSDOM(`<!DOCTYPE html><header>${post.yoast_head}</header>`)
+
+  const metaElements = dom.window.document.getElementsByTagName('meta')
+  const scriptElements = dom.window.document.getElementsByTagName('script')
+  const ldJson = scriptElements.length ? scriptElements[0].innerHTML : null
+
+  const metaTags: MetaTag[] = []
+
+  for (const element of metaElements) {
+    metaTags.push({
+      name: element.name,
+      property: element.getAttribute('property') ?? '',
+      content: element.content,
+    })
+  }
+
+  if (!metaTags.length || !ldJson) return null
+
+  return {
+    metaTags,
+    ldJson,
+  }
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -184,10 +184,10 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
-"@vtex/api@6.42.1":
-  version "6.42.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.42.1.tgz#b0030afa16750f995bf8296bdc8b22ce2fa5907b"
-  integrity sha512-b9U+G1ZuZ6MOsbiLn+/FEW/XnTIGnsKam1YxUf7OHJhPY+ebupkxIhFeAWub/Mf8xELaNl+0EdrwUbuq4dNFxQ==
+"@vtex/api@6.43.0":
+  version "6.43.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.43.0.tgz#f84ce6dcfcc96e3be5d6917437e21b66a1a7d267"
+  integrity sha512-NF2+x7XFE9D31oUb3U2i9UIZtakUKGAZKfRPYwdSpMQZits4wpL4jBcnjwX7Bufl9lZx3GfnLm0LabLI7vjAOw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/components/WordpressHeader.tsx
+++ b/react/components/WordpressHeader.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import { Helmet } from 'react-helmet'
 
-interface WordpressPostHeaderProps {
+interface WordpressHeaderProps {
   postData: PostData
   dataS: any
 }
@@ -12,10 +12,16 @@ const buildMetaTag = ({ name, property, content }: MetaTags) => {
   return <meta property={property} content={content} />
 }
 
-const WordpressPostHeader: FunctionComponent<WordpressPostHeaderProps> = props => {
+const WordpressHeader: FunctionComponent<WordpressHeaderProps> = props => {
   const { postData, dataS } = props
+  const {
+    type,
+    title,
+    featured_media: featuredMedia,
+    excerpt,
+    headerTags,
+  } = postData
 
-  const { title, featured_media: featuredMedia, excerpt, headerTags } = postData
   const headerTitle = dataS?.appSettings?.titleTag
     ? `${title.rendered} | ${dataS?.appSettings?.titleTag}`
     : title.rendered
@@ -30,6 +36,14 @@ const WordpressPostHeader: FunctionComponent<WordpressPostHeaderProps> = props =
     )
   }
 
+  const description =
+    type === 'page'
+      ? excerpt?.rendered
+          ?.replace(/<p>/gi, '')
+          .replace(/<\/p>/gi, '')
+          .trim()
+      : excerpt?.rendered?.replace(/(<([^>]+)>)/gi, '').trim()
+
   return (
     <Helmet>
       <title>{headerTitle}</title>
@@ -38,12 +52,9 @@ const WordpressPostHeader: FunctionComponent<WordpressPostHeaderProps> = props =
       ) : (
         ''
       )}
-      <meta
-        name="description"
-        content={excerpt?.rendered?.replace(/(<([^>]+)>)/gi, '').trim()}
-      />
+      <meta name="description" content={description} />
     </Helmet>
   )
 }
 
-export default WordpressPostHeader
+export default WordpressHeader

--- a/react/components/WordpressPage.tsx
+++ b/react/components/WordpressPage.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
 import React, { FunctionComponent, useMemo } from 'react'
-import { Helmet } from 'react-helmet'
 import { defineMessages, FormattedMessage } from 'react-intl'
 import { useQuery } from 'react-apollo'
 import { useRuntime } from 'vtex.render-runtime'
@@ -11,6 +10,7 @@ import { useCssHandles } from 'vtex.css-handles'
 
 import SinglePageBySlug from '../graphql/SinglePageBySlug.graphql'
 import Settings from '../graphql/Settings.graphql'
+import WordpressHeader from './WordpressHeader'
 
 interface PageProps {
   customDomains: string
@@ -138,14 +138,7 @@ const WordpressPageInner: FunctionComponent<{ pageData: any }> = props => {
     )
   }
 
-  const {
-    date,
-    title,
-    content,
-    author,
-    excerpt,
-    featured_media,
-  } = props.pageData
+  const { date, title, content, author, featured_media } = props.pageData
 
   const dateObj = new Date(date)
   const dateOptions = { year: 'numeric', month: 'long', day: 'numeric' }
@@ -181,26 +174,7 @@ const WordpressPageInner: FunctionComponent<{ pageData: any }> = props => {
   }
   return (
     <Container className={`${handles.postFlex} pt6 pb8 ph3`}>
-      <Helmet>
-        <title>
-          {dataS?.appSettings?.titleTag
-            ? `${title.rendered} | ${dataS.appSettings.titleTag}`
-            : title.rendered}
-        </title>
-        {featured_media?.media_type === 'image' &&
-        featured_media?.source_url ? (
-          <meta property="og:image" content={featured_media?.source_url} />
-        ) : (
-          ''
-        )}
-        <meta
-          name="description"
-          content={excerpt?.rendered
-            ?.replace(/<p>/gi, '')
-            .replace(/<\/p>/gi, '')
-            .trim()}
-        />
-      </Helmet>
+      <WordpressHeader postData={props.pageData} dataS={dataS} />
       <div className={`${handles.postContainer} ph3`}>
         <h1
           className={`${handles.postTitle} t-heading-1`}

--- a/react/components/WordpressPost.tsx
+++ b/react/components/WordpressPost.tsx
@@ -12,7 +12,7 @@ import { WPRelatedProductsContext } from '../contexts/WordpressRelatedProducts'
 import SinglePostBySlug from '../graphql/SinglePostBySlug.graphql'
 import Settings from '../graphql/Settings.graphql'
 import linkParams from '../utils/categoryLinkParams'
-import WordpressPostHeader from './WordpressPostHeader'
+import WordpressHeader from './WordpressHeader'
 
 interface PostProps {
   customDomains: string
@@ -227,7 +227,7 @@ const WordpressPostInner: FunctionComponent<WordpressPostInnerProps> = props => 
 
   return (
     <Container className={`${handles.postFlex} pt6 pb8 ph3`}>
-      <WordpressPostHeader postData={props.postData} dataS={dataS} />
+      <WordpressHeader postData={props.postData} dataS={dataS} />
       <div className={`${handles.postContainer} ph3`}>
         <h1
           className={`${handles.postTitle} t-heading-1`}

--- a/react/components/WordpressPost.tsx
+++ b/react/components/WordpressPost.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Container } from 'vtex.store-components'
 import React, { FunctionComponent, useMemo } from 'react'
-import { Helmet } from 'react-helmet'
 import { defineMessages, FormattedMessage } from 'react-intl'
 import { useQuery } from 'react-apollo'
 import { Link, useRuntime } from 'vtex.render-runtime'
@@ -13,6 +12,7 @@ import { WPRelatedProductsContext } from '../contexts/WordpressRelatedProducts'
 import SinglePostBySlug from '../graphql/SinglePostBySlug.graphql'
 import Settings from '../graphql/Settings.graphql'
 import linkParams from '../utils/categoryLinkParams'
+import WordpressPostHeader from './WordpressPostHeader'
 
 interface PostProps {
   customDomains: string
@@ -195,7 +195,6 @@ const WordpressPostInner: FunctionComponent<WordpressPostInnerProps> = props => 
     categories,
     content,
     featured_media,
-    excerpt,
     tags,
   } = props.postData
 
@@ -228,23 +227,7 @@ const WordpressPostInner: FunctionComponent<WordpressPostInnerProps> = props => 
 
   return (
     <Container className={`${handles.postFlex} pt6 pb8 ph3`}>
-      <Helmet>
-        <title>
-          {dataS?.appSettings?.titleTag
-            ? `${title.rendered} | ${dataS.appSettings.titleTag}`
-            : title.rendered}
-        </title>
-        {featured_media?.media_type === 'image' &&
-        featured_media?.source_url ? (
-          <meta property="og:image" content={featured_media?.source_url} />
-        ) : (
-          ''
-        )}
-        <meta
-          name="description"
-          content={excerpt?.rendered?.replace(/(<([^>]+)>)/gi, '').trim()}
-        />
-      </Helmet>
+      <WordpressPostHeader postData={props.postData} dataS={dataS} />
       <div className={`${handles.postContainer} ph3`}>
         <h1
           className={`${handles.postTitle} t-heading-1`}

--- a/react/components/WordpressPostHeader.tsx
+++ b/react/components/WordpressPostHeader.tsx
@@ -1,0 +1,49 @@
+import React, { FunctionComponent } from 'react'
+import { Helmet } from 'react-helmet'
+
+interface WordpressPostHeaderProps {
+  postData: PostData
+  dataS: any
+}
+
+const buildMetaTag = ({ name, property, content }: MetaTags) => {
+  if (name) return <meta name={name} content={content} />
+
+  return <meta property={property} content={content} />
+}
+
+const WordpressPostHeader: FunctionComponent<WordpressPostHeaderProps> = props => {
+  const { postData, dataS } = props
+
+  const { title, featured_media: featuredMedia, excerpt, headerTags } = postData
+  const headerTitle = dataS?.appSettings?.titleTag
+    ? `${title.rendered} | ${dataS?.appSettings?.titleTag}`
+    : title.rendered
+
+  if (headerTags) {
+    return (
+      <Helmet>
+        <title>{headerTitle}</title>
+        {headerTags.metaTags.map(tag => buildMetaTag(tag))}
+        <script type="application/ld+json">{headerTags.ldJson}</script>
+      </Helmet>
+    )
+  }
+
+  return (
+    <Helmet>
+      <title>{headerTitle}</title>
+      {featuredMedia?.media_type === 'image' && featuredMedia?.source_url ? (
+        <meta property="og:image" content={featuredMedia?.source_url} />
+      ) : (
+        ''
+      )}
+      <meta
+        name="description"
+        content={excerpt?.rendered?.replace(/(<([^>]+)>)/gi, '').trim()}
+      />
+    </Helmet>
+  )
+}
+
+export default WordpressPostHeader

--- a/react/graphql/SinglePostBySlug.graphql
+++ b/react/graphql/SinglePostBySlug.graphql
@@ -20,6 +20,14 @@ query SinglePostBySlug($slug: String!, $customDomain: String) {
         slug
       }
       date
+      headerTags {
+        metaTags {
+          name
+          property
+          content
+        }
+        ldJson
+      }
       featured_media(customDomain: $customDomain) {
         source_url
         alt_text

--- a/react/graphql/SinglePostBySlug.graphql
+++ b/react/graphql/SinglePostBySlug.graphql
@@ -20,6 +20,7 @@ query SinglePostBySlug($slug: String!, $customDomain: String) {
         slug
       }
       date
+      type
       headerTags {
         metaTags {
           name

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -17,6 +17,7 @@ interface PostData {
   excerpt: WPExcerpt
   categories: [WPCategory]
   featured_media: WPMedia
+  headerTags: HeaderTags
   tags: [WPTag]
 }
 
@@ -162,4 +163,15 @@ interface WPTag {
   slug: string
   taxonomy: WPTaxonomyType
   meta: string
+}
+
+interface HeaderTags {
+  metaTags: MetaTags[]
+  ldJson: string
+}
+
+interface MetaTags {
+  name: string
+  property: string
+  content: string
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -11,6 +11,7 @@ interface PostData {
   author: WPUser
   content: WPContent
   date: string
+  type: string
   id: number
   slug: string
   link: string


### PR DESCRIPTION
**What problem is this solving?**

The Yoast SEO WordPress plugin adds an additional property on returned post data, `yoast_head`. This PR adds support for integrations using this plugin.

If the property is present, the meta tags and structured data provided by Yoast will be used on the post page.

**How should this be manually tested?**

[workspace](https://yoast--arcaplanet.myvtex.com/blog/post/in-vacanza-con-il-proprio-animale-domestico-i-must-have-da-mettere-in-valigia) with Yoast plugin
**Screenshots or example usage:**

![Screenshot from 2021-06-29 13-20-11](https://user-images.githubusercontent.com/22715037/123840816-d271a500-d8dc-11eb-9064-b4787edd39fc.png)
