### PR TITLE
Displaying wrong categories on post teasers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Displaying wrong categories in post teasers
+
 ## [2.10.0] - 2021-06-30
 
 ### Added

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -204,7 +204,7 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
                 <WordpressTeaser
                   title={post.title.rendered}
                   author={post.author ? post.author.name : ''}
-                  categories={data.wpPosts.posts[0].categories}
+                  categories={post.categories}
                   subcategoryUrls={subcategoryUrls}
                   excerpt={post.excerpt.rendered}
                   date={post.date}


### PR DESCRIPTION
**What problem is this solving?**

Fix to display the correct category in the Teaser component.
<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

[workspace](https://sdb--corona.myvtex.com/blog)

**Screenshots or example usage:**

![Screenshot from 2021-07-02 12-38-16](https://user-images.githubusercontent.com/22715037/124305007-7acc7700-db32-11eb-8531-185598ac5539.png)
