### PR TITLE
Expand search to include a post's tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- When searching posts, query tag names that match the searched terms, and return the associated posts.
+
 ## [2.11.0] - 2021-07-19
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -547,6 +547,12 @@ type Query {
     sticky: Boolean
     customDomain: String
   ): WPPostsResult @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
+  wpPostsSearch(
+    page: Int = 1
+    per_page: Int = 10
+    search: String
+    customDomain: String
+  ): WPPostsResult @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
   wpPost(id: Int!, password: String, customDomain: String): WPPost
     @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
   wpCategories(

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,5 +1,6 @@
 import { LogLevel } from '@vtex/api'
 
+import searchPostTagsAndContent from '../utils/search'
 import { addCSShandles, addHeaderTags } from '../utils/jsdom'
 
 /* eslint-disable @typescript-eslint/camelcase */
@@ -97,6 +98,18 @@ export const queries = {
     const total_count = headers['x-wp-total']
     const result = { posts, total_count }
     return result
+  },
+  wpPostsSearch: async (
+    _: any,
+    query: {
+      page: number
+      per_page: number
+      search?: string
+      customDomain?: string
+    },
+    ctx: Context
+  ): Promise<{ posts: WpPost[]; total_count: number }> => {
+    return searchPostTagsAndContent(ctx, query)
   },
   wpPost: async (
     _: any,

--- a/node/utils/search.ts
+++ b/node/utils/search.ts
@@ -1,0 +1,87 @@
+import WordpressProxyDataSource from '../clients/wordpressProxy'
+
+const postsWithTag = async (
+  wordpressProxy: WordpressProxyDataSource,
+  { page, per_page: perPage, search, customDomain }: any
+) => {
+  const { data: tags } = await wordpressProxy.getTags({
+    slug: search,
+    customDomain,
+  })
+
+  const total = tags.reduce((sum, tag) => sum + tag.count, 0)
+
+  if (!total)
+    return {
+      pageOffset: 0,
+      partialPage: 0,
+      data: [],
+      total: 0,
+    }
+
+  const pages = Math.ceil(total / perPage)
+  const partialPage = perPage - (total % perPage)
+  const tagIds = tags.map(tag => tag.id)
+
+  if (page > pages) {
+    return {
+      pages,
+      partialPage,
+      tagIds,
+      data: [],
+      total,
+    }
+  }
+
+  const { data } = await wordpressProxy.getPosts({
+    page,
+    per_page: perPage,
+    tags: tagIds,
+    customDomain,
+  })
+
+  return {
+    pages,
+    partialPage,
+    tagIds,
+    data,
+    total,
+  }
+}
+const postsWithContent = async (
+  wordpressProxy: WordpressProxyDataSource,
+  { page, per_page: perPage, search, customDomain }: any,
+  { pages, partialPage, tagIds, data: tagPosts }: any
+) => {
+  const { headers, data } = await wordpressProxy.getPosts({
+    page: Math.max(page - pages, 1),
+    per_page: tagPosts.length ? partialPage : perPage,
+    search,
+    offset: tagPosts.length ? undefined : partialPage,
+    tags_exclude: tagIds || undefined,
+    customDomain,
+  })
+
+  const posts = tagPosts.length === perPage ? [] : data
+
+  return { data: posts, total: Number(headers['x-wp-total']) }
+}
+
+const searchPostTagsAndContent = async (ctx: Context, query: any) => {
+  const {
+    clients: { wordpressProxy },
+  } = ctx
+
+  const tagSearchResult = await postsWithTag(wordpressProxy, query)
+  const contentSearchResult = await postsWithContent(
+    wordpressProxy,
+    query,
+    tagSearchResult
+  )
+
+  return {
+    posts: [...tagSearchResult.data, ...contentSearchResult.data],
+    total_count: tagSearchResult.total + contentSearchResult.total,
+  }
+}
+export default searchPostTagsAndContent

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -111,7 +111,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
       currentItemTo={page * perPage}
       textOf="of"
       textShowRows="posts per page"
-      totalItems={data?.wpPosts?.total_count ?? 0}
+      totalItems={data?.wpPostsSearch?.total_count ?? 0}
       onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
         setPage(1)
         if (pages[id].path.indexOf(':page') > 0) {
@@ -229,12 +229,12 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
             Error: {error.message}
           </div>
         )}
-        {data?.wpPosts ? (
+        {data?.wpPostsSearch ? (
           <Fragment>
             <div
               className={`${handles.listFlex} ${handles.searchListFlex} mv4 flex flex-row flex-wrap`}
             >
-              {data.wpPosts.posts.map((post: PostData, index: number) => (
+              {data.wpPostsSearch.posts.map((post: PostData, index: number) => (
                 <div
                   key={index}
                   className={`${handles.listFlexItem} ${handles.searchListFlexItem} mv3 w-100-s w-50-l ph4`}

--- a/react/graphql/SearchPosts.graphql
+++ b/react/graphql/SearchPosts.graphql
@@ -4,7 +4,7 @@ query SearchPosts(
   $terms: String
   $customDomain: String
 ) {
-  wpPosts(
+  wpPostsSearch(
     page: $wp_page
     per_page: $wp_per_page
     search: $terms


### PR DESCRIPTION
**What problem is this solving?**

Default WordPress post search does not include a posts tags when querying posts; only title and content. 

This PR changes the search behavior to first search tag names by the search terms, and find the associated posts. Posts with a matching tag are returned, followed by the standard search results (a match in the post title or content).
  
<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

Search tag evgrMTB:
[workspace](https://tagsearch--eriksbikeshop.myvtex.com/blog/search/evgrMTB)
[current behavior](https://eriksbikeshop.myvtex.com/blog/search/evgrMTB)