### PR TITLE
Add support for slug_id URL param in Post Navigation and Page components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for `slug_id` URL param in `WordpressPostContainer`, `WordpressNavigation`, and `WordpressPage` components
+
 ## [2.12.0] - 2021-07-26
 
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
     "@types/he": "^1.1.0",
     "@types/jsdom": "^16.2.10",
     "@types/sanitize-html": "^1.20.2",
-    "@vtex/api": "6.43.1",
+    "@vtex/api": "6.44.0",
     "vtex.blog-interfaces": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.blog-interfaces@0.2.0/public/@types/vtex.blog-interfaces",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.9/public/@types/vtex.product-context",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -184,10 +184,10 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
-"@vtex/api@6.43.1":
-  version "6.43.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.43.1.tgz#3c69cc23af97d23729f970b332d740041dcc8d2e"
-  integrity sha512-4I7rb+PrXGwmy/ZlYC+wQlWT9nePMdMb3dNJ9wPGMYkAa8J12uA4SeHQP9Uzf+gEYLatliTKzL1cvEYrAR41gg==
+"@vtex/api@6.44.0":
+  version "6.44.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.44.0.tgz#8dc2a27c37635278117310bcc5cd16203c0a5849"
+  integrity sha512-7nPIwzQz55Mu0E1BOoW1noObZet9J34iKmeAJU3TRL7iiGmPZB0McSjC6KgDHkfqYgim2JGrnCsa1978ffbwKQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/components/WordpressPage.tsx
+++ b/react/components/WordpressPage.tsx
@@ -141,7 +141,11 @@ const WordpressPageInner: FunctionComponent<{ pageData: any }> = props => {
   const { date, title, content, author, featured_media } = props.pageData
 
   const dateObj = new Date(date)
-  const dateOptions = { year: 'numeric', month: 'long', day: 'numeric' }
+  const dateOptions: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }
   const formattedDate = dateObj.toLocaleDateString(locale, dateOptions)
 
   const titleHtml = useMemo(() => {
@@ -243,7 +247,8 @@ const WordpressPage: StorefrontFunctionComponent<PageProps> = ({
       : undefined
 
   const { loading, error, data } = useQuery(SinglePageBySlug, {
-    variables: { slug: params.slug, customDomain },
+    variables: { slug: params.slug || params.slug_id, customDomain },
+    skip: !params?.slug && !params?.slug_id,
   })
 
   if (loading) {

--- a/react/components/WordpressPost.tsx
+++ b/react/components/WordpressPost.tsx
@@ -199,7 +199,11 @@ const WordpressPostInner: FunctionComponent<WordpressPostInnerProps> = props => 
   } = props.postData
 
   const dateObj = new Date(date)
-  const dateOptions = { year: 'numeric', month: 'long', day: 'numeric' }
+  const dateOptions: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }
   const formattedDate = dateObj.toLocaleDateString(locale, dateOptions)
 
   const productIds = tags
@@ -318,6 +322,7 @@ const WordpressPost: StorefrontFunctionComponent<PostProps> = ({
 
   const { loading, error, data } = useQuery(SinglePostBySlug, {
     variables: { slug: params.slug || params.slug_id, customDomain },
+    skip: !params?.slug && !params?.slug_id,
   })
 
   if (loading) {

--- a/react/components/WordpressPostContainer.tsx
+++ b/react/components/WordpressPostContainer.tsx
@@ -28,7 +28,8 @@ const WordpressPostContainer: StorefrontFunctionComponent<PostProps> = props => 
       : undefined
 
   const query = useQuery(SinglePostBySlug, {
-    variables: { slug: params.slug, customDomain },
+    variables: { slug: params.slug || params.slug_id, customDomain },
+    skip: !params?.slug && !params?.slug_id,
   })
 
   return (

--- a/react/components/WordpressPostNavigation.tsx
+++ b/react/components/WordpressPostNavigation.tsx
@@ -51,7 +51,7 @@ const WordpressPostNavigation: StorefrontFunctionComponent = () => {
               <div>
                 <Link
                   page="store.blog-post"
-                  params={{ slug: slugPrev }}
+                  params={{ slug: slugPrev, slug_id: slugPrev }}
                   className={`${handles.postNavigationLink}`}
                 >
                   {dataPrev?.wpPosts?.posts[0]?.title.rendered}
@@ -74,7 +74,7 @@ const WordpressPostNavigation: StorefrontFunctionComponent = () => {
               <div>
                 <Link
                   page="store.blog-post"
-                  params={{ slug: slugNext }}
+                  params={{ slug: slugNext, slug_id: slugNext }}
                   className={`${handles.postNavigationLink}`}
                 >
                   {dataNext?.wpPosts?.posts[0]?.title.rendered}


### PR DESCRIPTION
**What problem is this solving?**

Slack thread: https://vtex.slack.com/archives/CFJU5HYTV/p1627058116052800

I discovered this problem was happening because the store was using a `slug_id` param in their store.blog-post route, and the WordpressPostNavigation only supported the plain `slug` param. This meant that the "next post / previous post" buttons failed to the direct the user to the correct page, and if the user tried to load a blog post page from scratch (rather than navigating to it from another page) a nasty error dump was displayed. This PR fixes the issue and adds support for `slug_id` in a few other places.

**How should this be manually tested?**

Linked here: https://blogtest--corona.myvtex.com/blog/post/fundacion-renaciendo
