### PR TITLE
Change default query arguments to enums instead of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Change default query arguments to enums instead of strings where appropriate
+
 ## [2.12.1] - 2021-08-02
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -166,8 +166,8 @@ type WPCategory {
     exclude: [Int]
     include: [Int]
     offset: Int
-    order: WPOrder = "desc"
-    orderby: WPOrderBy = "date"
+    order: WPOrder = desc
+    orderby: WPOrderBy = date
     slug: [String]
     status: [String] = ["publish"]
     tags: [Int]
@@ -205,8 +205,8 @@ type WPTag {
     exclude: [Int]
     include: [Int]
     offset: Int
-    order: WPOrder = "desc"
-    orderby: WPOrderBy = "date"
+    order: WPOrder = desc
+    orderby: WPOrderBy = date
     slug: [String]
     status: [String] = ["publish"]
     tags: [Int]
@@ -536,8 +536,8 @@ type Query {
     exclude: [Int]
     include: [Int]
     offset: Int
-    order: WPOrder = "desc"
-    orderby: WPOrderBy = "date"
+    order: WPOrder = desc
+    orderby: WPOrderBy = date
     slug: [String]
     status: [String] = ["publish"]
     categories: [Int]


### PR DESCRIPTION
**What problem is this solving?**

This app's GraphQL schema sets a few default argument values, such as "orderby=date", however these were not being respected because an enum value was expected (date) instead of a string ("date"). An example of a problem that this caused was the "next article" navigation button would always navigate to the newest blog post, instead of the "next newest". 

**How should this be manually tested?**

New version linked here: https://blogtest--corona.myvtex.com/blog/post/new-in