### PR TITLE
Make pagination text optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Option to hide Pagination "Posts Per Page" text in app settings.
+
 ## [2.12.2] - 2021-08-02
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -511,6 +511,7 @@ type WPUsersResult {
 type Settings {
   titleTag: String
   blogRoute: String
+  displayShowRowsText: Boolean
 }
 
 type HeaderTags {

--- a/manifest.json
+++ b/manifest.json
@@ -38,9 +38,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "settingsSchema": {
     "title": "Wordpress Integration",
@@ -65,6 +63,12 @@
         "title": "Store blog home path",
         "description": "The app adds blog URLs to the sitemap, allowing for these pages to be index by search engines. Enter the path used to the store's blog home page, as found in the theme's `routes.json` file. Enter the string used without a beginning or ending slash, if '/blog', simply enter 'blog'",
         "type": "string"
+      },
+      "displayShowRowsText": {
+        "title": "Display 'Posts Per Page' in Pagination",
+        "description": "In the Pagination component, display the 'Posts Per Page' text",
+        "type": "boolean",
+        "default": true
       },
       "initializeSitemap": {
         "title": "Create Sitemap Entries",

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -91,7 +91,11 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
       currentItemFrom={(page - 1) * perPage + 1}
       currentItemTo={page * perPage}
       textOf="of"
-      textShowRows="posts per page"
+      textShowRows={
+        dataS?.appSettings?.displayShowRowsText === false
+          ? null
+          : 'posts per page'
+      }
       totalItems={data?.wpPosts?.total_count ?? 0}
       onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
         setPage(1)

--- a/react/components/WordpressCategory.tsx
+++ b/react/components/WordpressCategory.tsx
@@ -107,7 +107,11 @@ const WordpressCategory: StorefrontFunctionComponent<CategoryProps> = ({
       currentItemFrom={(page - 1) * perPage + 1}
       currentItemTo={page * perPage}
       textOf="of"
-      textShowRows="posts per page"
+      textShowRows={
+        dataS?.appSettings?.displayShowRowsText === false
+          ? null
+          : 'posts per page'
+      }
       totalItems={data?.wpCategories?.categories[0]?.wpPosts?.total_count ?? 0}
       onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
         setPage(1)

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -15,6 +15,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import WordpressTeaser from './WordpressTeaser'
 import withSearchContext from './withSearchContext'
 import SearchPosts from '../graphql/SearchPosts.graphql'
+import Settings from '../graphql/Settings.graphql'
 
 interface Props {
   searchQuery: any
@@ -46,6 +47,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
   const [page, setPage] = useState(1)
   const [perPage, setPerPage] = useState(postsPerPage)
   const handles = useCssHandles(CSS_HANDLES)
+  const { data: dataS } = useQuery(Settings)
   const { loading, error, data, fetchMore } = useQuery(SearchPosts, {
     skip: !searchQuery,
     variables: {
@@ -87,7 +89,11 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
       currentItemFrom={(page - 1) * perPage + 1}
       currentItemTo={page * perPage}
       textOf="of"
-      textShowRows="posts per page"
+      textShowRows={
+        dataS?.appSettings?.displayShowRowsText === false
+          ? null
+          : 'posts per page'
+      }
       totalItems={data?.wpPosts?.total_count ?? 0}
       onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
         setPage(1)

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -110,7 +110,11 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
       currentItemFrom={(page - 1) * perPage + 1}
       currentItemTo={page * perPage}
       textOf="of"
-      textShowRows="posts per page"
+      textShowRows={
+        dataS?.appSettings?.displayShowRowsText === false
+          ? null
+          : 'posts per page'
+      }
       totalItems={data?.wpPostsSearch?.total_count ?? 0}
       onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
         setPage(1)

--- a/react/graphql/Settings.graphql
+++ b/react/graphql/Settings.graphql
@@ -1,5 +1,6 @@
 query Settings {
   appSettings {
     titleTag
+    displayShowRowsText
   }
 }


### PR DESCRIPTION
**What problem is this solving?**

Make `Posts Per Page` text in the Pagination component optional through the app settings.

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**
[workspace](https://sdb--ametllerorigen.myvtex.com/blog?__bindingAddress=www.ametllerorigen.com/ca)
**Screenshots or example usage:**
![Screenshot from 2021-08-03 12-36-07](https://user-images.githubusercontent.com/22715037/128053875-00fd5ebd-1a9b-439d-922a-4337ecc4d052.png)
