### PR TITLE
Fix product term search query for posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed product term search query for posts
+
 ## [2.12.3] - 2021-08-05
 
 ### Added

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1641,7 +1641,7 @@ source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/components/WordpressProductSearchResult.tsx
+++ b/react/components/WordpressProductSearchResult.tsx
@@ -98,7 +98,7 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
           : // eslint-disable-next-line @typescript-eslint/no-use-before-define
             intl.formatMessage(messages.postsPerPage)
       }
-      totalItems={data?.wpPosts?.total_count ?? 0}
+      totalItems={data?.wpPostsSearch?.total_count ?? 0}
       onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
         setSelectedOption(+value)
         setPage(1)
@@ -179,12 +179,12 @@ const WordpressSearchResult: StorefrontFunctionComponent<Props> = ({
             Error: {error.message}
           </div>
         )}
-        {data?.wpPosts ? (
+        {data?.wpPostsSearch ? (
           <Fragment>
             <div
               className={`${handles.listFlex} ${handles.searchListFlex} mv4 flex flex-row flex-wrap`}
             >
-              {data.wpPosts.posts.map((post: PostData, index: number) => (
+              {data.wpPostsSearch.posts.map((post: PostData, index: number) => (
                 <div
                   key={index}
                   className={`${handles.listFlexItem} ${handles.searchListFlexItem} mv3 w-100-s w-50-l ph4`}


### PR DESCRIPTION
**What problem is this solving?**

Blog post search results for VTEX product search do not appear in the search page. This is a fix for the problem.

**How should this be manually tested?**

Visit [this page](https://wordpressdev--eriksbikeshop.myvtex.com/kids%20bikes?map=ft).

**Screenshots or example usage:**

![Screenshot 2021-08-12 at 10 25 52 PM](https://user-images.githubusercontent.com/42151054/129237460-71185c86-4155-405b-b3d5-7cc80cb7f69e.png)
