### PR TITLE
Option to ignore robots meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Option to ignore robots meta tag from Yoast SEO plugin.
+
 ## [2.12.4] - 2021-08-12
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -38,9 +38,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "settingsSchema": {
     "title": "Wordpress Integration",
@@ -71,6 +69,12 @@
         "description": "In the Pagination component, display the 'Posts Per Page' text",
         "type": "boolean",
         "default": true
+      },
+      "ignoreRobotsMetaTag": {
+        "title": "Ignore Yoast SEO Robots Meta Tag",
+        "description": "Ignore the robots meta tag that is provided by the Yoast SEO plugin. This option only applies if you are using the Yoast SEO plugin in your WordPress installation",
+        "type": "boolean",
+        "default": false
       },
       "initializeSitemap": {
         "title": "Create Sitemap Entries",

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -93,7 +93,7 @@ export const queries = {
     const posts = data
     if (data.length) {
       posts[0].content.rendered = addCSShandles(data[0].content.rendered)
-      posts[0].headerTags = addHeaderTags(data[0])
+      posts[0].headerTags = await addHeaderTags(ctx, data[0])
     }
     const total_count = headers['x-wp-total']
     const result = { posts, total_count }
@@ -329,7 +329,7 @@ export const queries = {
     const pages = data
     if (data.length) {
       pages[0].content.rendered = addCSShandles(data[0].content.rendered)
-      pages[0].headerTags = addHeaderTags(data[0])
+      pages[0].headerTags = addHeaderTags(ctx, data[0])
     }
     const total_count = headers['x-wp-total']
     const result = { pages, total_count }

--- a/node/utils/jsdom.ts
+++ b/node/utils/jsdom.ts
@@ -29,8 +29,15 @@ export const addCSShandles = (content: string) => {
   return document.body.innerHTML
 }
 
-export const addHeaderTags = (post: WpPost): HeaderTags | null => {
+export const addHeaderTags = async (
+  ctx: Context,
+  post: WpPost
+): Promise<HeaderTags | null> => {
   if (!post.yoast_head) return null
+
+  const settings = await ctx.clients.apps.getAppSettings(
+    process.env.VTEX_APP_ID as string
+  )
 
   const dom = new JSDOM(`<!DOCTYPE html><header>${post.yoast_head}</header>`)
 
@@ -41,6 +48,10 @@ export const addHeaderTags = (post: WpPost): HeaderTags | null => {
   const metaTags: MetaTag[] = []
 
   for (const element of metaElements) {
+    if (element.name === 'robots' && settings.ignoreRobotsMetaTag) {
+      continue
+    }
+
     metaTags.push({
       name: element.name,
       property: element.getAttribute('property') ?? '',


### PR DESCRIPTION
**What problem is this solving?**

Stores using the WordPress app may want to prevent Google from indexing blog pages at the domain hosting their WordPress installation; and only index the blog pages at their VTEX store. Yoast SEO is passing a `noindex` robots meta tag in these cases. 

This PR adds an option to ignore the robots meta tag coming from the Yoast SEO plugin.

[workspace](https://sdb--eriksbikeshop.myvtex.com/blog/post/all-new-45nrth-winter-clothing-and-boots-released)


with robots meta:

![Screenshot from 2021-08-13 12-47-45](https://user-images.githubusercontent.com/22715037/129392764-853f55e3-3934-4bc1-a8e9-493ce6b35ec1.png)


removed robots meta:

![Screenshot from 2021-08-13 12-46-25](https://user-images.githubusercontent.com/22715037/129392762-d0cafb33-2147-4ddf-8339-7ff3ac16a34e.png)



