### PR TITLE
Feature/usaappteam 32 filter block added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add filters in WordpressAllPosts and WordpressSearchResult.
+
 ## [2.14.0] - 2021-09-01
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ In your VTEX account's admin, perform the following actions:
 5. If your Wordpress installation's API is hosted under a path other than `wp-json/wp/v2/`, enter the path in the **Wordpress API path** field. For example, if the `posts` endpoint looks like `https://example.wordpress.com/index.php?rest_route=/wp/v2/posts`, enter `index.php?rest_route=/wp/v2/` here. If unsure, leave the field blank.
 6. Enter the **Title tag for block homepage** which will determine the title tag for the Wordpress portions of your store.
 7. Enter the **Store blog home path** which is used to include Wordpress posts in the sitemap and be indexed by search engines. For example, the path to your store's blog is www.my-store.com/blog, you would enter 'blog'.
-8. Select the filters that you want to show, this filters will appear as part of the pagination in the both search posts and all posts views, you can filter by category or/and tag.
+8. Select the filters that you want to show, this filters will appear as part of the pagination in both search posts and all posts views, you can filter by category or/and tag.
 9. Save your changes.
 
 ⚠️ If you have a security plugin installed on your WordPress installation (such as WordFence), ensure it is not blocking requests to `/users` or `/?author=N` queries.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,8 @@ In your VTEX account's admin, perform the following actions:
 5. If your Wordpress installation's API is hosted under a path other than `wp-json/wp/v2/`, enter the path in the **Wordpress API path** field. For example, if the `posts` endpoint looks like `https://example.wordpress.com/index.php?rest_route=/wp/v2/posts`, enter `index.php?rest_route=/wp/v2/` here. If unsure, leave the field blank.
 6. Enter the **Title tag for block homepage** which will determine the title tag for the Wordpress portions of your store.
 7. Enter the **Store blog home path** which is used to include Wordpress posts in the sitemap and be indexed by search engines. For example, the path to your store's blog is www.my-store.com/blog, you would enter 'blog'.
-8. Save your changes.
+8. Select the filters that you want to show, this filters will appear as part of the pagination in the both search posts and all posts views, you can filter by category or/and tag.
+9. Save your changes.
 
 ⚠️ If you have a security plugin installed on your WordPress installation (such as WordFence), ensure it is not blocking requests to `/users` or `/?author=N` queries.
 
@@ -428,6 +429,8 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `categoryBlockFlex`                    |
 | `categoryBlockFlexItem`                |
 | `categoryBlockLink`                    |
+| `categorySelectContainer`              |
+| `filtersContainer`                     |
 | `latestPostsBlockContainer`            |
 | `latestPostsBlockTitle`                |
 | `latestPostsBlockFlex`                 |
@@ -470,6 +473,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `searchResultBlockFlex`                |
 | `searchResultBlockFlexItem`            |
 | `searchResultBlockLink`                |
+| `tagSelectContainer`                   |
 | `teaserAuthor`                         |
 | `teaserCategoryLink`                   |
 | `teaserContainer`                      |

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -520,6 +520,8 @@ type Settings {
   titleTag: String
   blogRoute: String
   displayShowRowsText: Boolean
+  filterByCategories: Boolean
+  filterByTags: Boolean
 }
 
 type HeaderTags {

--- a/manifest.json
+++ b/manifest.json
@@ -84,6 +84,18 @@
         "description": "Create the initial sitemap entries (/blog-posts and /blog-categories) in the stores root sitemap. If setting up the app for the first time, leave this enabled so the sitemap is updated with these entries. If this is not the first time you have set up the Wordpress app, ensure the sitemap entries are not in your sitemap before changing this setting, it could result in duplicate sitemap entries.",
         "type": "boolean",
         "default": true
+      },
+      "filterByCategories": {
+        "title": "Filter by categories",
+        "description": "Show a dropdown containing all categories allowing you to filter your posts by the selected category.",
+        "type": "boolean",
+        "default": false
+      },
+      "filterByTags": {
+        "title": "Filter by tags",
+        "description": "Show a dropdown containing all tags allowing you to filter your posts by the selected tag.",
+        "type": "boolean",
+        "default": false
       }
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -87,13 +87,13 @@
       },
       "filterByCategories": {
         "title": "Filter by categories",
-        "description": "Show a dropdown containing all categories allowing you to filter your posts by the selected category.",
+        "description": "Shows a dropdown containing all categories allowing you to filter your posts by the selected category.",
         "type": "boolean",
         "default": false
       },
       "filterByTags": {
         "title": "Filter by tags",
-        "description": "Show a dropdown containing all tags allowing you to filter your posts by the selected tag.",
+        "description": "Shows a dropdown containing all tags allowing you to filter your posts by the selected tag.",
         "type": "boolean",
         "default": false
       }

--- a/messages/context.json
+++ b/messages/context.json
@@ -84,5 +84,9 @@
   "store/wordpress-integration.wordpressPost.postedIn": "store/wordpress-integration.wordpressPost.postedIn",
   "store/wordpress-integration.wordpressPost.byAuthor": "store/wordpress-integration.wordpressPost.byAuthor",
   "store/wordpress-integration.wordpressPage.posted": "store/wordpress-integration.wordpressPage.posted",
-  "store/wordpress-integration.wordpressPage.byAuthor": "store/wordpress-integration.wordpressPage.byAuthor"
+  "store/wordpress-integration.wordpressPage.byAuthor": "store/wordpress-integration.wordpressPage.byAuthor",
+  "store/wordpress-integration.wordpressCategorySelect.allCategories": "store/wordpress-integration.wordpressCategorySelect.allCategories",
+  "store/wordpress-integration.wordpressCategorySelect.filterByCategory": "store/wordpress-integration.wordpressCategorySelect.filterByCategory",
+  "store/wordpress-integration.WordpressTagSelect.allTags": "store/wordpress-integration.WordpressTagSelect.allTags",
+  "store/wordpress-integration.WordpressTagSelect.filterByTag": "store/wordpress-integration.WordpressTagSelect.filterByTag" 
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -85,5 +85,9 @@
   "store/wordpress-integration.wordpressPost.postedIn": "Posted {formattedDate} in ",
   "store/wordpress-integration.wordpressPost.byAuthor": " by {name}",
   "store/wordpress-integration.wordpressPage.posted": "Posted {formattedDate} ",
-  "store/wordpress-integration.wordpressPage.byAuthor": " by {name}"
+  "store/wordpress-integration.wordpressPage.byAuthor": " by {name}",
+  "store/wordpress-integration.wordpressCategorySelect.allCategories": "All categories",
+  "store/wordpress-integration.wordpressCategorySelect.filterByCategory": "Filter by category",
+  "store/wordpress-integration.WordpressTagSelect.allTags": "All tags",
+  "store/wordpress-integration.WordpressTagSelect.filterByTag": "Filter by tags"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -85,5 +85,9 @@
   "store/wordpress-integration.wordpressPost.postedIn": "Publicado {formattedDate} en ",
   "store/wordpress-integration.wordpressPost.byAuthor": " por {name}",
   "store/wordpress-integration.wordpressPage.posted": "Publicado {formattedDate} ",
-  "store/wordpress-integration.wordpressPage.byAuthor": " por {name}"
+  "store/wordpress-integration.wordpressPage.byAuthor": " por {name}",
+  "store/wordpress-integration.wordpressCategorySelect.allCategories": "Todas las categorías",
+  "store/wordpress-integration.wordpressCategorySelect.filterByCategory": "Filtrar por categoría",
+  "store/wordpress-integration.WordpressTagSelect.allTags": "Todas las etiquetas",
+  "store/wordpress-integration.WordpressTagSelect.filterByTag": "Filtrar por etiquetas"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -85,5 +85,9 @@
   "store/wordpress-integration.wordpressPost.postedIn": "Postado {formattedDate} em ",
   "store/wordpress-integration.wordpressPost.byAuthor": " por {name}",
   "store/wordpress-integration.wordpressPage.posted": "Postado {formattedDate} ",
-  "store/wordpress-integration.wordpressPage.byAuthor": " por {name}"
+  "store/wordpress-integration.wordpressPage.byAuthor": " por {name}",
+  "store/wordpress-integration.wordpressCategorySelect.allCategories": "Todas as categorias",
+  "store/wordpress-integration.wordpressCategorySelect.filterByCategory": "Filtrar por categoria",
+  "store/wordpress-integration.WordpressTagSelect.allTags": "Todas as tags",
+  "store/wordpress-integration.WordpressTagSelect.filterByTag": "Filtrar por tags"
 }

--- a/node/typings/appSettings.d.ts
+++ b/node/typings/appSettings.d.ts
@@ -7,6 +7,8 @@ interface Settings {
   displayShowRowsText?: boolean
   ignoreRobotsMetaTag?: boolean
   initializeSitemap?: boolean
+  filterByCategories?: boolean
+  filterByTags?: boolean
 }
 
 interface AppSettings extends Settings {

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -233,33 +233,66 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
       {data?.wpPosts ? (
         <Fragment>
           <div className={`${handles.listFlex} mv4 flex flex-row flex-wrap`}>
-            {data.wpPosts.posts.map((post: PostData, index: number) => (
-              <div
-                key={index}
-                className={`${handles.listFlexItem} mv3 w-100-s w-50-l ph4`}
-              >
-                <WordpressTeaser
-                  title={post.title.rendered}
-                  author={post.author ? post.author.name : ''}
-                  categories={post.categories}
-                  subcategoryUrls={subcategoryUrls}
-                  excerpt={post.excerpt.rendered}
-                  date={post.date}
-                  id={post.id}
-                  slug={post.slug}
-                  link={post.link}
-                  customDomainSlug={customDomainSlug}
-                  featuredMedia={post.featured_media}
-                  mediaSize={mediaSize}
-                  showAuthor={false}
-                  showCategory
-                  showDate
-                  showExcerpt
-                  useTextOverlay={false}
-                  absoluteLinks={false}
-                />
-              </div>
-            ))}
+            {(selectedCategory && selectedCategory !== "all") ?
+              data.wpPosts.posts
+                .filter((post: any) => post.categories.find((category: any) => category.name === selectedCategory))
+                .map((post: PostData, index: number) => (
+                  <div
+                    key={index}
+                    className={`${handles.listFlexItem} mv3 w-100-s w-50-l ph4`}
+                  >
+                    <WordpressTeaser
+                      title={post.title.rendered}
+                      author={post.author ? post.author.name : ''}
+                      categories={post.categories}
+                      subcategoryUrls={subcategoryUrls}
+                      excerpt={post.excerpt.rendered}
+                      date={post.date}
+                      id={post.id}
+                      slug={post.slug}
+                      link={post.link}
+                      customDomainSlug={customDomainSlug}
+                      featuredMedia={post.featured_media}
+                      mediaSize={mediaSize}
+                      showAuthor={false}
+                      showCategory
+                      showDate
+                      showExcerpt
+                      useTextOverlay={false}
+                      absoluteLinks={false}
+                    />
+                  </div>
+                ))
+              :
+              data.wpPosts.posts
+                .map((post: PostData, index: number) => (
+                  <div
+                    key={index}
+                    className={`${handles.listFlexItem} mv3 w-100-s w-50-l ph4`}
+                  >
+                    <WordpressTeaser
+                      title={post.title.rendered}
+                      author={post.author ? post.author.name : ''}
+                      categories={post.categories}
+                      subcategoryUrls={subcategoryUrls}
+                      excerpt={post.excerpt.rendered}
+                      date={post.date}
+                      id={post.id}
+                      slug={post.slug}
+                      link={post.link}
+                      customDomainSlug={customDomainSlug}
+                      featuredMedia={post.featured_media}
+                      mediaSize={mediaSize}
+                      showAuthor={false}
+                      showCategory
+                      showDate
+                      showExcerpt
+                      useTextOverlay={false}
+                      absoluteLinks={false}
+                    />
+                  </div>
+                ))
+            }
           </div>
           <div className={`${handles.paginationComponent} ph3 mb7`}>
             {PaginationComponent}

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -27,7 +27,7 @@ const CSS_HANDLES = [
   'listFlexItem',
   'paginationComponent',
   'categorySelect',
-  'tagSelect'
+  'tagSelect',
 ] as const
 
 interface AllPostsProps {
@@ -57,9 +57,9 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
   const [page, setPage] = useState(parseInt(initialPage, 10))
   const [perPage, setPerPage] = useState(postsPerPage)
   const [selectedOption, setSelectedOption] = useState(postsPerPage)
-  const [selectedCategory, setSelectedCategory] = useState("")
+  const [selectedCategory, setSelectedCategory] = useState('')
   const [categories, setCategories] = useState([])
-  const [selectedTag, setSelectedTag] = useState("")
+  const [selectedTag, setSelectedTag] = useState('')
   const [tags, setTags] = useState([])
   const handles = useCssHandles(CSS_HANDLES)
   const { loading: loadingS, data: dataS } = useQuery(Settings)
@@ -92,28 +92,22 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
     }
   }, [page])
   useEffect(() => {
-    console.log(data);
-
-    setCategories(data.wpPosts.posts
-      .reduce((acc: any, el: any) => [...acc, ...el.categories], [])
-      .reduce((acc: any, current: any) => {
-        const x = acc.find((item: any) => item.id === current.id);
-        if (!x) {
-          return acc.concat([current]);
-        } else {
-          return acc;
-        }
-      }, []))
-    setTags(data.wpPosts.posts
-      .reduce((acc: any, el: any) => [...acc, ...el.tags], [])
-      .reduce((acc: any, current: any) => {
-        const x = acc.find((item: any) => item.id === current.id);
-        if (!x) {
-          return acc.concat([current]);
-        } else {
-          return acc;
-        }
-      }, []))
+    setCategories(
+      data.wpPosts.posts
+        .reduce((acc: any, el: any) => [...acc, ...el.categories], [])
+        .reduce((acc: any, current: any) => {
+          const x = acc.find((item: any) => item.id === current.id)
+          return !x ? acc.concat([current]) : acc
+        }, [])
+    )
+    setTags(
+      data.wpPosts.posts
+        .reduce((acc: any, el: any) => [...acc, ...el.tags], [])
+        .reduce((acc: any, el: any) => {
+          const x = acc.find((item: any) => item.id === el.id)
+          return !x ? acc.concat([el]) : acc
+        }, [])
+    )
   }, [data])
 
   const PaginationComponent = (
@@ -132,7 +126,7 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
         dataS?.appSettings?.displayShowRowsText === false
           ? null
           : // eslint-disable-next-line @typescript-eslint/no-use-before-define
-          intl.formatMessage(messages.postsPerPage)
+            intl.formatMessage(messages.postsPerPage)
       }
       totalItems={data?.wpPosts?.total_count ?? 0}
       onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
@@ -229,7 +223,9 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
       <div className={`${handles.paginationComponent} ph3`}>
         {PaginationComponent}
       </div>
-      <div className={`${handles.categorySelect} flex flex-row justify-between mt3 ph3`}>
+      <div
+        className={`${handles.categorySelect} flex flex-row justify-between mt3 ph3`}
+      >
         {dataS?.appSettings?.filterByCategories && (
           <div className={`w-40`}>
             <WordpressCategorySelect
@@ -262,49 +258,47 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
       {data?.wpPosts ? (
         <Fragment>
           <div className={`${handles.listFlex} mv4 flex flex-row flex-wrap`}>
-            {
-              data.wpPosts.posts
-                .filter((post: any) => (
-                  (
-                    (selectedCategory && selectedCategory !== "all") ? (
-                      post.categories.find((category: any) => category.name === selectedCategory)
-                    ) : post
-                  )
-                  &&
-                  (
-                    (selectedTag && selectedTag !== "all") ? (
-                      post.tags.find((tag: any) => tag.id == selectedTag)
-                    ) : post
-                  )
-                ))
-                .map((post: PostData, index: number) => (
-                  <div
-                    key={index}
-                    className={`${handles.listFlexItem} mv3 w-100-s w-50-l ph4`}
-                  >
-                    <WordpressTeaser
-                      title={post.title.rendered}
-                      author={post.author ? post.author.name : ''}
-                      categories={post.categories}
-                      subcategoryUrls={subcategoryUrls}
-                      excerpt={post.excerpt.rendered}
-                      date={post.date}
-                      id={post.id}
-                      slug={post.slug}
-                      link={post.link}
-                      customDomainSlug={customDomainSlug}
-                      featuredMedia={post.featured_media}
-                      mediaSize={mediaSize}
-                      showAuthor={false}
-                      showCategory
-                      showDate
-                      showExcerpt
-                      useTextOverlay={false}
-                      absoluteLinks={false}
-                    />
-                  </div>
-                ))
-            }
+            {data.wpPosts.posts
+              .filter(
+                (post: any) =>
+                  (selectedCategory && selectedCategory !== 'all'
+                    ? post.categories.find(
+                        (category: any) => category.name === selectedCategory
+                      )
+                    : post) &&
+                  (selectedTag && selectedTag !== 'all'
+                    ? post.tags.find(
+                        (tag: any) => tag.id === parseInt(selectedTag, 10)
+                      )
+                    : post)
+              )
+              .map((post: PostData, index: number) => (
+                <div
+                  key={index}
+                  className={`${handles.listFlexItem} mv3 w-100-s w-50-l ph4`}
+                >
+                  <WordpressTeaser
+                    title={post.title.rendered}
+                    author={post.author ? post.author.name : ''}
+                    categories={post.categories}
+                    subcategoryUrls={subcategoryUrls}
+                    excerpt={post.excerpt.rendered}
+                    date={post.date}
+                    id={post.id}
+                    slug={post.slug}
+                    link={post.link}
+                    customDomainSlug={customDomainSlug}
+                    featuredMedia={post.featured_media}
+                    mediaSize={mediaSize}
+                    showAuthor={false}
+                    showCategory
+                    showDate
+                    showExcerpt
+                    useTextOverlay={false}
+                    absoluteLinks={false}
+                  />
+                </div>
+              ))}
           </div>
           <div className={`${handles.paginationComponent} ph3 mb7`}>
             {PaginationComponent}

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -17,6 +17,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import WordpressTeaser from './WordpressTeaser'
 import Settings from '../graphql/Settings.graphql'
 import AllPosts from '../graphql/AllPosts.graphql'
+import WordpressCategorySelect from './WordpressCategorySelect'
 
 const CSS_HANDLES = [
   'listTitle',
@@ -24,6 +25,7 @@ const CSS_HANDLES = [
   'listFlex',
   'listFlexItem',
   'paginationComponent',
+  'categorySelect'
 ] as const
 
 interface AllPostsProps {
@@ -53,6 +55,8 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
   const [page, setPage] = useState(parseInt(initialPage, 10))
   const [perPage, setPerPage] = useState(postsPerPage)
   const [selectedOption, setSelectedOption] = useState(postsPerPage)
+  const [selectedCategory, setSelectedCategory] = useState("")
+  const [categories, setCategories] = useState([])
   const handles = useCssHandles(CSS_HANDLES)
   const { loading: loadingS, data: dataS } = useQuery(Settings)
   const { loading, error, data, fetchMore } = useQuery(AllPosts, {
@@ -83,6 +87,18 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
       })
     }
   }, [page])
+  useEffect(() => {
+    setCategories(data.wpPosts.posts
+      .reduce((acc: any, el: any) => [...acc, ...el.categories], [])
+      .reduce((acc: any, current: any) => {
+        const x = acc.find((item: any) => item.id === current.id);
+        if (!x) {
+          return acc.concat([current]);
+        } else {
+          return acc;
+        }
+      }, []))
+  }, [data])
 
   const PaginationComponent = (
     <Pagination
@@ -100,7 +116,7 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
         dataS?.appSettings?.displayShowRowsText === false
           ? null
           : // eslint-disable-next-line @typescript-eslint/no-use-before-define
-            intl.formatMessage(messages.postsPerPage)
+          intl.formatMessage(messages.postsPerPage)
       }
       totalItems={data?.wpPosts?.total_count ?? 0}
       onRowsChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
@@ -196,6 +212,13 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
       )}
       <div className={`${handles.paginationComponent} ph3`}>
         {PaginationComponent}
+      </div>
+      <div className={`${handles.categorySelect} mt3 ph3`}>
+        <WordpressCategorySelect
+          categories={categories}
+          selectedCategory={selectedCategory}
+          setSelectedCategory={setSelectedCategory}
+        />
       </div>
       {(loading || loadingS) && (
         <div className="mv5 flex justify-center" style={{ minHeight: 800 }}>

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -26,8 +26,9 @@ const CSS_HANDLES = [
   'listFlex',
   'listFlexItem',
   'paginationComponent',
-  'categorySelect',
-  'tagSelect',
+  'filtersContainer',
+  'categorySelectContainer',
+  'tagSelectContainer',
 ] as const
 
 interface AllPostsProps {
@@ -224,10 +225,10 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
         {PaginationComponent}
       </div>
       <div
-        className={`${handles.categorySelect} flex flex-row justify-between mt3 ph3`}
+        className={`${handles.filtersContainer} flex flex-row justify-between mt3 ph3`}
       >
         {dataS?.appSettings?.filterByCategories && (
-          <div className={`w-40`}>
+          <div className={`${handles.categorySelectContainer} w-40`}>
             <WordpressCategorySelect
               categories={categories}
               selectedCategory={selectedCategory}
@@ -236,7 +237,7 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
           </div>
         )}
         {dataS?.appSettings?.filterByTags && (
-          <div className={`w-40`}>
+          <div className={`${handles.tagSelectContainer} w-40`}>
             <WordpressTagSelect
               selectedTag={selectedTag}
               setSelectedTag={setSelectedTag}

--- a/react/components/WordpressAllPosts.tsx
+++ b/react/components/WordpressAllPosts.tsx
@@ -93,22 +93,24 @@ const WordpressAllPosts: StorefrontFunctionComponent<AllPostsProps> = ({
     }
   }, [page])
   useEffect(() => {
-    setCategories(
-      data.wpPosts.posts
-        .reduce((acc: any, el: any) => [...acc, ...el.categories], [])
-        .reduce((acc: any, current: any) => {
-          const x = acc.find((item: any) => item.id === current.id)
-          return !x ? acc.concat([current]) : acc
-        }, [])
-    )
-    setTags(
-      data.wpPosts.posts
-        .reduce((acc: any, el: any) => [...acc, ...el.tags], [])
-        .reduce((acc: any, el: any) => {
-          const x = acc.find((item: any) => item.id === el.id)
-          return !x ? acc.concat([el]) : acc
-        }, [])
-    )
+    data &&
+      setCategories(
+        data.wpPosts.posts
+          .reduce((acc: any, el: any) => [...acc, ...el.categories], [])
+          .reduce((acc: any, current: any) => {
+            const x = acc.find((item: any) => item.id === current.id)
+            return !x ? acc.concat([current]) : acc
+          }, [])
+      )
+    data &&
+      setTags(
+        data.wpPosts.posts
+          .reduce((acc: any, el: any) => [...acc, ...el.tags], [])
+          .reduce((acc: any, el: any) => {
+            const x = acc.find((item: any) => item.id === el.id)
+            return !x ? acc.concat([el]) : acc
+          }, [])
+      )
   }, [data])
 
   const PaginationComponent = (

--- a/react/components/WordpressCategorySelect.tsx
+++ b/react/components/WordpressCategorySelect.tsx
@@ -15,7 +15,7 @@ const WordpressCategorySelect: StorefrontFunctionComponent<WordpressCategorySele
 }) => {
 
   const categoryOptions = [
-    { value: "all", label: "All" },
+    { value: "all", label: "All categories" },
     ...categories.map((cat: any) => (
       { value: cat.name, label: cat.name }
     ))

--- a/react/components/WordpressCategorySelect.tsx
+++ b/react/components/WordpressCategorySelect.tsx
@@ -2,34 +2,32 @@ import React from 'react'
 import { Dropdown } from 'vtex.styleguide'
 import { defineMessages, useIntl } from 'react-intl'
 
-
 interface WordpressCategorySelectProps {
-  categories: any,
-  selectedCategory: any,
+  categories: any
+  selectedCategory: any
   setSelectedCategory: any
 }
 
 const WordpressCategorySelect: StorefrontFunctionComponent<WordpressCategorySelectProps> = ({
   categories,
   selectedCategory,
-  setSelectedCategory
+  setSelectedCategory,
 }) => {
-
   const intl = useIntl()
 
   const categoryOptions = [
     {
-      value: "all",
-      label: intl.formatMessage(messages.allCategories) 
+      value: 'all',
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      label: intl.formatMessage(messages.allCategories),
     },
-    ...categories.map((cat: any) => (
-      { value: cat.name, label: cat.name }
-    ))
+    ...categories.map((cat: any) => ({ value: cat.name, label: cat.name })),
   ]
 
   return (
     <Dropdown
-      placeholder={ intl.formatMessage(messages.filterByCategory) }
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      placeholder={intl.formatMessage(messages.filterByCategory)}
       options={categoryOptions}
       value={selectedCategory}
       onChange={(_: any, v: any) => setSelectedCategory(v)}
@@ -45,7 +43,7 @@ const messages = defineMessages({
   filterByCategory: {
     defaultMessage: 'Filter by category',
     id: 'store/wordpress-integration.wordpressCategorySelect.filterByCategory',
-  }
+  },
 })
 
 export default WordpressCategorySelect

--- a/react/components/WordpressCategorySelect.tsx
+++ b/react/components/WordpressCategorySelect.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Dropdown } from 'vtex.styleguide'
-import { FormattedMessage } from 'react-intl'
+import { defineMessages, useIntl } from 'react-intl'
 
 
 interface WordpressCategorySelectProps {
@@ -15,10 +15,12 @@ const WordpressCategorySelect: StorefrontFunctionComponent<WordpressCategorySele
   setSelectedCategory
 }) => {
 
+  const intl = useIntl()
+
   const categoryOptions = [
     {
       value: "all",
-      label: "All categories"
+      label: intl.formatMessage(messages.allCategories) 
     },
     ...categories.map((cat: any) => (
       { value: cat.name, label: cat.name }
@@ -27,12 +29,7 @@ const WordpressCategorySelect: StorefrontFunctionComponent<WordpressCategorySele
 
   return (
     <Dropdown
-      placeholder={
-        <FormattedMessage
-          id={'store/wordpress-integration.wordpressCategorySelect.filterByCategory'}
-          defaultMessage={'Filter by category'}
-        />
-      }
+      placeholder={ intl.formatMessage(messages.filterByCategory) }
       options={categoryOptions}
       value={selectedCategory}
       onChange={(_: any, v: any) => setSelectedCategory(v)}
@@ -40,5 +37,15 @@ const WordpressCategorySelect: StorefrontFunctionComponent<WordpressCategorySele
   )
 }
 
+const messages = defineMessages({
+  allCategories: {
+    defaultMessage: 'All categories',
+    id: 'store/wordpress-integration.wordpressCategorySelect.allCategories',
+  },
+  filterByCategory: {
+    defaultMessage: 'Filter by category',
+    id: 'store/wordpress-integration.wordpressCategorySelect.filterByCategory',
+  }
+})
 
 export default WordpressCategorySelect

--- a/react/components/WordpressCategorySelect.tsx
+++ b/react/components/WordpressCategorySelect.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Dropdown } from 'vtex.styleguide'
+
+
+interface WordpressCategorySelectProps {
+  categories: any,
+  selectedCategory: any,
+  setSelectedCategory: any
+}
+
+const WordpressCategorySelect: StorefrontFunctionComponent<WordpressCategorySelectProps> = ({
+  categories,
+  selectedCategory,
+  setSelectedCategory
+}) => {
+
+  const categoryOptions = [
+    { value: "all", label: "All" },
+    ...categories.map((cat: any) => (
+      { value: cat.name, label: cat.name }
+    ))
+  ]
+
+  return (
+    <Dropdown
+      placeholder="Filter by category"
+      options={categoryOptions}
+      value={selectedCategory}
+      onChange={(_: any, v: any) => setSelectedCategory(v)}
+    />
+  )
+
+  
+}
+
+
+export default WordpressCategorySelect

--- a/react/components/WordpressCategorySelect.tsx
+++ b/react/components/WordpressCategorySelect.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Dropdown } from 'vtex.styleguide'
+import { FormattedMessage } from 'react-intl'
 
 
 interface WordpressCategorySelectProps {
@@ -15,7 +16,10 @@ const WordpressCategorySelect: StorefrontFunctionComponent<WordpressCategorySele
 }) => {
 
   const categoryOptions = [
-    { value: "all", label: "All categories" },
+    {
+      value: "all",
+      label: "All categories"
+    },
     ...categories.map((cat: any) => (
       { value: cat.name, label: cat.name }
     ))
@@ -23,14 +27,17 @@ const WordpressCategorySelect: StorefrontFunctionComponent<WordpressCategorySele
 
   return (
     <Dropdown
-      placeholder="Filter by category"
+      placeholder={
+        <FormattedMessage
+          id={'store/wordpress-integration.wordpressCategorySelect.filterByCategory'}
+          defaultMessage={'Filter by category'}
+        />
+      }
       options={categoryOptions}
       value={selectedCategory}
       onChange={(_: any, v: any) => setSelectedCategory(v)}
     />
   )
-
-  
 }
 
 

--- a/react/components/WordpressSearchResult.tsx
+++ b/react/components/WordpressSearchResult.tsx
@@ -36,7 +36,8 @@ const CSS_HANDLES = [
   'listFlexItem',
   'searchListFlexItem',
   'paginationComponent',
-  'categorySelect',
+  'filtersContainer',
+  'categorySelectContainer',
 ] as const
 
 const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
@@ -246,10 +247,10 @@ const WordpressSearchResult: StorefrontFunctionComponent<SearchProps> = ({
           {paginationComponent}
         </div>
         <div
-          className={`${handles.categorySelect} flex flex-row justify-between mt3 ph3`}
+          className={`${handles.filtersContainer} flex flex-row justify-between mt3 ph3`}
         >
           {dataS?.appSettings?.filterByCategories && (
-            <div className={`w-40`}>
+            <div className={`${handles.categorySelectContainer} w-40`}>
               <WordpressCategorySelect
                 categories={categories}
                 selectedCategory={selectedCategory}

--- a/react/components/WordpressTagSelect.tsx
+++ b/react/components/WordpressTagSelect.tsx
@@ -20,7 +20,7 @@ const WordpressTagSelect: StorefrontFunctionComponent<WordpressTagSelectProps> =
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       label: intl.formatMessage(messages.allTags),
     },
-    ...tags.map((tag: any) => ({ value: tag.id, label: tag.name })),
+    ...tags.map((tag: any) => ({ value: tag.name, label: tag.name })),
   ]
 
   return (

--- a/react/components/WordpressTagSelect.tsx
+++ b/react/components/WordpressTagSelect.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Dropdown } from 'vtex.styleguide'
-import { FormattedMessage } from 'react-intl'
-
+import { defineMessages, useIntl } from 'react-intl'
 
 interface WordpressTagSelectProps {
   tags: any,
@@ -14,34 +13,36 @@ const WordpressTagSelect: StorefrontFunctionComponent<WordpressTagSelectProps> =
   selectedTag,
   setSelectedTag
 }) => {
-
+  const intl = useIntl()
   const tagOptions = [
     {
-      value: "all", label: "All tags"
+      value: "all", label: intl.formatMessage(messages.allTags) 
     },
     ...tags.map((tag: any) => (
-      { value: tag["id"].toString(), label: tag["__typename"] }
+      { value: tag.id, label: tag.__typename }
     ))
   ]
 
-  useEffect(() => {
-    console.log("tagOptions:", tagOptions);
-  }, [tags])
-
   return (
     <Dropdown
-      placeholder={
-        <FormattedMessage
-          id={'store/wordpress-integration.WordpressTagSelect.filterByTag'}
-          defaultMessage={'Filter by tag'}
-        />
-      }
+      placeholder={ intl.formatMessage(messages.filterByTag) }
       options={tagOptions}
       value={selectedTag}
       onChange={(_: any, l: any) => setSelectedTag(l)}
     />
   )
 }
+
+const messages = defineMessages({
+  allTags: {
+    defaultMessage: 'All tags',
+    id: "store/wordpress-integration.WordpressTagSelect.allTags"
+  },
+  filterByTag: {
+    defaultMessage: 'Filter by tag',
+    id: "store/wordpress-integration.WordpressTagSelect.filterByTag"
+  }
+})
 
 
 export default WordpressTagSelect

--- a/react/components/WordpressTagSelect.tsx
+++ b/react/components/WordpressTagSelect.tsx
@@ -3,29 +3,30 @@ import { Dropdown } from 'vtex.styleguide'
 import { defineMessages, useIntl } from 'react-intl'
 
 interface WordpressTagSelectProps {
-  tags: any,
-  selectedTag: any,
+  tags: any
+  selectedTag: any
   setSelectedTag: any
 }
 
 const WordpressTagSelect: StorefrontFunctionComponent<WordpressTagSelectProps> = ({
   tags,
   selectedTag,
-  setSelectedTag
+  setSelectedTag,
 }) => {
   const intl = useIntl()
   const tagOptions = [
     {
-      value: "all", label: intl.formatMessage(messages.allTags) 
+      value: 'all',
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      label: intl.formatMessage(messages.allTags),
     },
-    ...tags.map((tag: any) => (
-      { value: tag.id, label: tag.__typename }
-    ))
+    ...tags.map((tag: any) => ({ value: tag.id, label: tag.__typename })),
   ]
 
   return (
     <Dropdown
-      placeholder={ intl.formatMessage(messages.filterByTag) }
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      placeholder={intl.formatMessage(messages.filterByTag)}
       options={tagOptions}
       value={selectedTag}
       onChange={(_: any, l: any) => setSelectedTag(l)}
@@ -36,13 +37,12 @@ const WordpressTagSelect: StorefrontFunctionComponent<WordpressTagSelectProps> =
 const messages = defineMessages({
   allTags: {
     defaultMessage: 'All tags',
-    id: "store/wordpress-integration.WordpressTagSelect.allTags"
+    id: 'store/wordpress-integration.WordpressTagSelect.allTags',
   },
   filterByTag: {
     defaultMessage: 'Filter by tag',
-    id: "store/wordpress-integration.WordpressTagSelect.filterByTag"
-  }
+    id: 'store/wordpress-integration.WordpressTagSelect.filterByTag',
+  },
 })
-
 
 export default WordpressTagSelect

--- a/react/components/WordpressTagSelect.tsx
+++ b/react/components/WordpressTagSelect.tsx
@@ -1,5 +1,6 @@
-import React, {useEffect} from 'react'
+import React, { useEffect } from 'react'
 import { Dropdown } from 'vtex.styleguide'
+import { FormattedMessage } from 'react-intl'
 
 
 interface WordpressTagSelectProps {
@@ -8,48 +9,39 @@ interface WordpressTagSelectProps {
   setSelectedTag: any
 }
 
-const WordpressCategorySelect: StorefrontFunctionComponent<WordpressTagSelectProps> = ({
+const WordpressTagSelect: StorefrontFunctionComponent<WordpressTagSelectProps> = ({
   tags,
   selectedTag,
   setSelectedTag
 }) => {
 
-  
-
-
-
-  // const tagOptions = [
-  //   { value: 'all', label: 'All' },
-  //   { value: 'mastercard', label: 'Mastercard' },
-  //   { value: 'elo', label: 'Elo' },
-  //   { value: 'diners', label: 'Diners' },
-  //   { value: 'giftcard', label: 'Gift Card' },
-  //   { value: 'amex', label: 'American Express' },
-  // ]
-
   const tagOptions = [
-    { value: "all", label: "All tags" },
+    {
+      value: "all", label: "All tags"
+    },
     ...tags.map((tag: any) => (
-      { value: tag["id"].toString(), label: tag["id"] }
+      { value: tag["id"].toString(), label: tag["__typename"] }
     ))
   ]
 
   useEffect(() => {
-   console.log("tagOptions:", tagOptions);
-   
+    console.log("tagOptions:", tagOptions);
   }, [tags])
 
   return (
     <Dropdown
-      placeholder="Filter by tag"
+      placeholder={
+        <FormattedMessage
+          id={'store/wordpress-integration.WordpressTagSelect.filterByTag'}
+          defaultMessage={'Filter by tag'}
+        />
+      }
       options={tagOptions}
       value={selectedTag}
       onChange={(_: any, l: any) => setSelectedTag(l)}
     />
   )
-
-  
 }
 
 
-export default WordpressCategorySelect
+export default WordpressTagSelect

--- a/react/components/WordpressTagSelect.tsx
+++ b/react/components/WordpressTagSelect.tsx
@@ -20,7 +20,7 @@ const WordpressTagSelect: StorefrontFunctionComponent<WordpressTagSelectProps> =
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       label: intl.formatMessage(messages.allTags),
     },
-    ...tags.map((tag: any) => ({ value: tag.id, label: tag.__typename })),
+    ...tags.map((tag: any) => ({ value: tag.id, label: tag.name })),
   ]
 
   return (

--- a/react/components/WordpressTagSelect.tsx
+++ b/react/components/WordpressTagSelect.tsx
@@ -1,0 +1,55 @@
+import React, {useEffect} from 'react'
+import { Dropdown } from 'vtex.styleguide'
+
+
+interface WordpressTagSelectProps {
+  tags: any,
+  selectedTag: any,
+  setSelectedTag: any
+}
+
+const WordpressCategorySelect: StorefrontFunctionComponent<WordpressTagSelectProps> = ({
+  tags,
+  selectedTag,
+  setSelectedTag
+}) => {
+
+  
+
+
+
+  // const tagOptions = [
+  //   { value: 'all', label: 'All' },
+  //   { value: 'mastercard', label: 'Mastercard' },
+  //   { value: 'elo', label: 'Elo' },
+  //   { value: 'diners', label: 'Diners' },
+  //   { value: 'giftcard', label: 'Gift Card' },
+  //   { value: 'amex', label: 'American Express' },
+  // ]
+
+  const tagOptions = [
+    { value: "all", label: "All tags" },
+    ...tags.map((tag: any) => (
+      { value: tag["id"].toString(), label: tag["id"] }
+    ))
+  ]
+
+  useEffect(() => {
+   console.log("tagOptions:", tagOptions);
+   
+  }, [tags])
+
+  return (
+    <Dropdown
+      placeholder="Filter by tag"
+      options={tagOptions}
+      value={selectedTag}
+      onChange={(_: any, l: any) => setSelectedTag(l)}
+    />
+  )
+
+  
+}
+
+
+export default WordpressCategorySelect

--- a/react/graphql/AllPosts.graphql
+++ b/react/graphql/AllPosts.graphql
@@ -26,6 +26,7 @@ query AllPosts(
       }
       tags {
         id
+        name
       }
       categories(customDomain: $customDomain) {
         name

--- a/react/graphql/SearchPosts.graphql
+++ b/react/graphql/SearchPosts.graphql
@@ -20,6 +20,10 @@ query SearchPosts(
       excerpt {
         rendered
       }
+      tags {
+        id
+        name
+      }
       categories(customDomain: $customDomain) {
         name
         id

--- a/react/graphql/Settings.graphql
+++ b/react/graphql/Settings.graphql
@@ -2,5 +2,7 @@ query Settings {
   appSettings {
     titleTag
     displayShowRowsText
+    filterByCategories
+    filterByTags
   }
 }


### PR DESCRIPTION
**What problem is this solving?**
There was no way to filter posts by category or tags on the all posts component, now it can be done by two optional drop-downs that allow select either a category or tag to filter those posts. 

By default those selectors are not showed, but you can activate these blocks on your `wordpress-integration` settings.

**How should this be manually tested?**
[workspace](https://arturodev--sandboxusdev.myvtex.com/blog)

**Screenshots or example usage:**
![Screen Shot 2021-09-02 at 13 25 05](https://user-images.githubusercontent.com/49737670/131896919-800b64fe-73bc-4efb-929b-8bbd1db3f93d.png)
