### PR TITLE
Use store's routes to generate sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Remove blog URL path entry in app settings and use store's routes to build sitemap
+
 ## [2.15.0] - 2021-09-07
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -38,9 +38,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "settingsSchema": {
     "title": "Wordpress Integration",
@@ -60,11 +58,6 @@
       "titleTag": {
         "title": "Title tag for blog homepage",
         "description": "Will also be appended to inner blog pages",
-        "type": "string"
-      },
-      "blogPath": {
-        "title": "Store blog home path",
-        "description": "The app adds blog URLs to the sitemap, allowing for these pages to be index by search engines. Enter the path used to the store's blog home page, as found in the theme's `routes.json` file. Enter the string used without a beginning or ending slash, if '/blog', simply enter 'blog'",
         "type": "string"
       },
       "displayShowRowsText": {
@@ -112,6 +105,13 @@
       "attrs": {
         "host": "*",
         "path": "/wp-json/wp/v2/*"
+      }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "*",
+        "path": "/?__pickRuntime=pages"
       }
     },
     {

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,6 +1,7 @@
 import { ClientsConfig, IOClients, LRUCache } from '@vtex/api'
 
 import Sitemap from './sitemap'
+import StoreRoutes from './storeRoutes'
 import WordpressProxyDataSource from './wordpressProxy'
 
 const TIMEOUT_MS = 8000
@@ -17,6 +18,10 @@ metrics.trackCache('wordpressProxy', cacheStorage)
 export class Clients extends IOClients {
   public get wordpressProxy() {
     return this.getOrSet('wordpressProxy', WordpressProxyDataSource)
+  }
+
+  public get storeRoutes() {
+    return this.getOrSet('storeRoutes', StoreRoutes)
   }
 
   public get sitemap() {

--- a/node/clients/storeRoutes.ts
+++ b/node/clients/storeRoutes.ts
@@ -1,0 +1,43 @@
+import { InstanceOptions, IOContext, ExternalClient } from '@vtex/api'
+
+type BlogPage = 'store.blog-post' | 'store.blog-category'
+interface PagesRuntime {
+  pages: {
+    [key: string]: {
+      allowConditions: boolean
+      context: unknown
+      declarer: string
+      path: string
+      routeId: string
+      blockId: string
+      map: unknown
+    }
+  }
+}
+
+export default class StoreRoutes extends ExternalClient {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super('', context, options)
+  }
+
+  public async getPath(page: BlogPage) {
+    try {
+      const routes = await this.http.get<PagesRuntime>(
+        `http://${this.context.host}/?__pickRuntime=pages`,
+        {
+          headers: {
+            'X-Vtex-Use-Https': true,
+            Cookie: `VtexIdclientAutCookie=${this.context.authToken}`,
+          },
+        }
+      )
+
+      const route = routes.pages[page].path
+      const [path] = route.split(':')
+
+      return path
+    } catch (error) {
+      return ''
+    }
+  }
+}

--- a/node/clients/storeRoutes.ts
+++ b/node/clients/storeRoutes.ts
@@ -21,9 +21,13 @@ export default class StoreRoutes extends ExternalClient {
   }
 
   public async getPath(page: BlogPage) {
+    const workspace = this.context.production
+      ? ''
+      : `${this.context.workspace}--`
+
     try {
       const routes = await this.http.get<PagesRuntime>(
-        `http://${this.context.host}/?__pickRuntime=pages`,
+        `http://${workspace}${this.context.account}.myvtex.com/?__pickRuntime=pages`,
         {
           headers: {
             'X-Vtex-Use-Https': true,

--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
     "@types/he": "^1.1.0",
     "@types/jsdom": "^16.2.10",
     "@types/sanitize-html": "^1.20.2",
-    "@vtex/api": "6.45.3",
+    "@vtex/api": "6.45.4",
     "vtex.blog-interfaces": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.blog-interfaces@0.2.0/public/@types/vtex.blog-interfaces",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.9/public/@types/vtex.product-context",

--- a/node/resolvers/routes.ts
+++ b/node/resolvers/routes.ts
@@ -1,124 +1,140 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { LogLevel, method } from '@vtex/api'
+
 import { queries } from './index'
 
 const API_MAX_QUANTITY = 100
 
+const buildSitemap = (entries: string[]) => {
+  return `
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">${
+    entries.length ? entries.join('') : ''
+  }</urlset>`
+}
+
+const buildEntries = ({
+  entries,
+  date,
+  host,
+  path,
+}: {
+  entries: Array<WpCategory | WpPost> | null
+  date: string
+  host: string | undefined
+  path: string
+}) => {
+  if (!entries || !host) return []
+
+  return entries.map(
+    entry => `<url>
+                <loc>https://${host}${path}${entry.slug}</loc>
+                <lastmod>${date}</lastmod>
+                <changefreq>monthly</changefreq>
+                <priority>0.7</priority>
+                </url>`
+  )
+}
+
 export const routes = {
   postsSitemap: method({
-    GET: async (ctx: any) => {
-      const { blogPath = 'blog' } = await queries.appSettings(null, null, ctx)
-      const quantity = API_MAX_QUANTITY
-      let page = 1
-      let total = 0
-      let runningTotal = 0
-
+    GET: async (ctx: Context) => {
+      const path = await ctx.clients.storeRoutes.getPath('store.blog-post')
       const sitemapContent = []
 
-      try {
-        do {
-          // eslint-disable-next-line no-await-in-loop
-          const response = await queries.wpPosts(
-            null,
-            {
-              page,
-              per_page: quantity,
-              order: 'desc',
-              orderby: 'date',
-              status: ['publish'],
-            },
-            ctx
-          )
+      if (path) {
+        const quantity = API_MAX_QUANTITY
+        const date = new Date().toISOString()
 
-          const lastMod = new Date().toISOString()
-          const entries = response.posts?.map(post => {
-            return `<url>
-          <loc>https://${ctx.vtex.host}/${blogPath}/post/${post.slug}</loc>
-          <lastmod>${lastMod}</lastmod>
-          <changefreq>monthly</changefreq>
-          <priority>0.7</priority>
-       </url>`
-          })
+        let page = 1
+        let total = 0
+        let runningTotal = 0
 
-          if (entries) {
+        try {
+          do {
+            // eslint-disable-next-line no-await-in-loop
+            const response = await queries.wpPosts(
+              null,
+              {
+                page,
+                per_page: quantity,
+                order: 'desc',
+                orderby: 'date',
+                status: ['publish'],
+              },
+              ctx
+            )
+
+            const entries = buildEntries({
+              entries: response?.posts,
+              host: ctx.vtex.host,
+              date,
+              path,
+            })
+
             sitemapContent.push(...entries)
-          }
 
-          total = parseInt(response?.total_count, 10) || 0
-          runningTotal += API_MAX_QUANTITY
-          page += 1
-        } while (total > runningTotal)
-
-        const sitemap = `
-        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-        ${sitemapContent.join('')}</urlset>`
-
-        ctx.set('Content-Type', 'text/xml')
-        ctx.body = sitemap
-        ctx.status = 200
-      } catch (err) {
-        ctx.vtex.logger.log(err, LogLevel.Error)
-        ctx.body = err
-        ctx.status = 500
+            total = parseInt(response?.total_count, 10) || 0
+            runningTotal += API_MAX_QUANTITY
+            page += 1
+          } while (total > runningTotal)
+        } catch (err) {
+          ctx.vtex.logger.log(err, LogLevel.Error)
+        }
       }
+
+      ctx.set('Content-Type', 'text/xml')
+      ctx.body = buildSitemap(sitemapContent)
+      ctx.status = 200
     },
   }),
   categoriesSitemap: method({
-    GET: async (ctx: any) => {
-      const { blogPath = 'blog' } = await queries.appSettings(null, null, ctx)
-      const quantity = API_MAX_QUANTITY
-      let page = 1
-      let total = 0
-      let runningTotal = 0
-
+    GET: async (ctx: Context) => {
+      const path = await ctx.clients.storeRoutes.getPath('store.blog-category')
       const sitemapContent = []
 
-      try {
-        do {
-          // eslint-disable-next-line no-await-in-loop
-          const response = await queries.wpCategories(
-            null,
-            {
-              page,
-              per_page: quantity,
-              order: 'desc',
-              orderby: 'name',
-              hide_empty: true,
-            },
-            ctx
-          )
+      if (path) {
+        const quantity = API_MAX_QUANTITY
+        const date = new Date().toISOString()
+        let page = 1
+        let total = 0
+        let runningTotal = 0
 
-          const lastMod = new Date().toISOString()
-          const entries = response.categories?.map((category: any) => {
-            return `<url>
-          <loc>https://${ctx.vtex.host}/${blogPath}/category/${category.slug}</loc>
-          <lastmod>${lastMod}</lastmod>
-          <changefreq>monthly</changefreq>
-          <priority>0.7</priority>
-       </url>`
-          })
+        try {
+          do {
+            // eslint-disable-next-line no-await-in-loop
+            const response = await queries.wpCategories(
+              null,
+              {
+                page,
+                per_page: quantity,
+                order: 'desc',
+                orderby: 'name',
+                hide_empty: true,
+              },
+              ctx
+            )
 
-          if (entries) {
+            const entries = buildEntries({
+              entries: response?.categories,
+              host: ctx.vtex.host,
+              date,
+              path,
+            })
+
             sitemapContent.push(...entries)
-          }
 
-          total = parseInt(response?.total_count, 10) || 0
-          runningTotal += API_MAX_QUANTITY
-          page += 1
-        } while (total > runningTotal)
-
-        const sitemap = `
-          <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-           ${sitemapContent.join('')}</urlset>`
-
-        ctx.set('Content-Type', 'text/xml')
-        ctx.body = sitemap
-        ctx.status = 200
-      } catch (err) {
-        ctx.vtex.logger.log(err, LogLevel.Error)
-        ctx.body = err
-        ctx.status = 500
+            total = parseInt(response?.total_count, 10) || 0
+            runningTotal += API_MAX_QUANTITY
+            page += 1
+          } while (total > runningTotal)
+        } catch (err) {
+          ctx.vtex.logger.log(err, LogLevel.Error)
+        }
       }
+
+      ctx.set('Content-Type', 'text/xml')
+      ctx.body = buildSitemap(sitemapContent)
+      ctx.status = 200
     },
   }),
 }

--- a/node/typings/appSettings.d.ts
+++ b/node/typings/appSettings.d.ts
@@ -3,7 +3,6 @@ interface Settings {
   endpoint?: string
   apiPath?: string
   titleTag?: string
-  blogPath?: string
   displayShowRowsText?: boolean
   ignoreRobotsMetaTag?: boolean
   initializeSitemap?: boolean

--- a/node/utils/bindings.ts
+++ b/node/utils/bindings.ts
@@ -1,0 +1,16 @@
+import { TenantClient } from '@vtex/api'
+
+export const TENANT_CACHE_TTL_S = 60 * 10
+export const STORE_PRODUCT = 'vtex-storefront'
+
+export const getStoreBindings = async (tenant: TenantClient) => {
+  const { bindings } = await tenant.info({
+    forceMaxAge: TENANT_CACHE_TTL_S,
+  })
+
+  const storeBindings = bindings.filter(
+    binding => binding.targetProduct === STORE_PRODUCT
+  )
+
+  return storeBindings
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -184,10 +184,10 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
-"@vtex/api@6.45.3":
-  version "6.45.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.3.tgz#fe7d08adb4eab1fda5e34143cc6302a4c5aa5f52"
-  integrity sha512-kiD7We1TCKDyBdpYoh2Se3An+jTJRUzXGNpKifoDZylWQ1PyIx+3oL5ZAif9InlY3uJkfEisSAI6nxoKTgvPfw==
+"@vtex/api@6.45.4":
+  version "6.45.4"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.4.tgz#58be7497c0c0f91a388fabd42149e48cb95e271d"
+  integrity sha512-DVAJr5BkSjXupjn2h5Z1In8C3Li9kZwCXPwRQbpIgyS7s9dN2ZEFQc6nQlJm6ZoDCoyYBg62LgD7Kurvz9jc3w==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
**What problem is this solving?**

Currently, if a store does not use `/blog/post` or `/blog/category`, the generated sitemaps are incorrect. `/post` and `/category` are hard-coded in the app, and `/blog` can be changed, but must be manually configured in the WordPress app settings.

This PR will use the store's `routes.json` to fetch the URL paths used for the WordPress app blocks. This allows us to build the blog sitemap entries without any hard-coded or manually entered data.

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

[posts](http://sdb--sandboxusdev.myvtex.com/sitemap/blog-posts.xml)
[categories](http://sdb--sandboxusdev.myvtex.com/sitemap/blog-categories.xml)

[categories](https://sdb--arcaplanet.myvtex.com/sitemap/blog-categories.xml)
[posts](https://sdb--arcaplanet.myvtex.com/sitemap/blog-posts.xml)

routes.json in these examples:
```
  "store.blog-home": {
    "path": "/learn"
  },
  "store.blog-category": {
    "path": "/learn/category/:categoryslug_id"
  },
  "store.blog-post": {
    "path": "/learn/:slug_id"
  }
```