### PR TITLE
feat: pagination Wordpress header (prev next canonical)

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
     "@types/he": "^1.1.0",
     "@types/jsdom": "^16.2.10",
     "@types/sanitize-html": "^1.20.2",
-    "@vtex/api": "6.45.4",
+    "@vtex/api": "6.45.6",
     "vtex.blog-interfaces": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.blog-interfaces@0.2.0/public/@types/vtex.blog-interfaces",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.9/public/@types/vtex.product-context",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -184,10 +184,10 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
-"@vtex/api@6.45.4":
-  version "6.45.4"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.4.tgz#58be7497c0c0f91a388fabd42149e48cb95e271d"
-  integrity sha512-DVAJr5BkSjXupjn2h5Z1In8C3Li9kZwCXPwRQbpIgyS7s9dN2ZEFQc6nQlJm6ZoDCoyYBg62LgD7Kurvz9jc3w==
+"@vtex/api@6.45.6":
+  version "6.45.6"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.6.tgz#e5f08476d7c76f26baa1c040666d1364bdd6bc35"
+  integrity sha512-9pDiUxcUzq8RZa9yBex4C8dcAHXBRGAZokvHJ6sykrojq6mJxs+rUTE28TPeeQxwvvKsvrdpsfCUAYQ+UDz+zA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/components/WordpressHeader.tsx
+++ b/react/components/WordpressHeader.tsx
@@ -4,6 +4,8 @@ import { Helmet } from 'react-helmet'
 interface WordpressHeaderProps {
   postData: PostData
   dataS: any
+  totalPages?: number
+  currentPage?: number
 }
 
 const buildMetaTag = ({ name, property, content }: MetaTags) => {
@@ -13,7 +15,7 @@ const buildMetaTag = ({ name, property, content }: MetaTags) => {
 }
 
 const WordpressHeader: FunctionComponent<WordpressHeaderProps> = props => {
-  const { postData, dataS } = props
+  const { postData, dataS, totalPages, currentPage } = props
   const {
     type,
     title,
@@ -47,6 +49,10 @@ const WordpressHeader: FunctionComponent<WordpressHeaderProps> = props => {
   return (
     <Helmet>
       <title>{headerTitle}</title>
+      {currentPage && currentPage > 1 &&
+        <link data-react-helmet="true" rel="prev" href={`${window?.location?.href?.split('?')[0]}?page=${currentPage - 1}`} />}
+      {totalPages && currentPage && currentPage < totalPages &&
+        <link data-react-helmet="true" rel="next" href={`${window?.location?.href?.split('?')[0]}?page=${currentPage + 1}`} />}
       {featuredMedia?.media_type === 'image' && featuredMedia?.source_url ? (
         <meta property="og:image" content={featuredMedia?.source_url} />
       ) : (


### PR DESCRIPTION
**add pagination WordpressHeader**

Now we don’t have pagination (prev next, and page= value) in the wordpress header, that can helps crawlers can better perceive the blog


**Screenshots or example usage:**
![image](https://user-images.githubusercontent.com/51743718/144212639-6a17bfd1-3d5c-4618-8b75-4d86e315813b.png)

