### PR TITLE
fix: add featured_image property

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -14,6 +14,7 @@ type WPPost {
   author(customDomain: String): WPUser
   excerpt: WPExcerpt
   featured_media(customDomain: String): WPMedia
+  featured_image: String
   comment_status: WPOpenClosed
   ping_status: WPOpenClosed
   format: WPFormat


### PR DESCRIPTION
Add property featured_image in WPost type, this property returns the preview image link in some cases

### Example
![image](https://user-images.githubusercontent.com/46490801/152200908-4f8097bf-ca93-47fa-8263-e4f21c40f5ae.png)

**What problem is this solving?**

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

**Screenshots or example usage:**