### PR TITLE
[WORDPRESS-28] Use the category of the first product to be used as te…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Take the search terms from the params, if no params terms, use first product category to create the terms.
+
 ## [2.18.1] - 2022-03-09
 
 ### Fixed

--- a/node/clients/wordpressProxy.ts
+++ b/node/clients/wordpressProxy.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { ExternalClient, InstanceOptions, IOContext, Apps } from '@vtex/api'
 
 const DEFAULT_API_PATH = 'wp-json/wp/v2/'
@@ -77,7 +78,6 @@ export default class WordpressProxyDataSource extends ExternalClient {
       combinedArgs = await this.buildArgs(wpOptions)
       if (wpOptions.customDomain) endpoint = wpOptions.customDomain
     }
-
     return this.http.getRaw<WpPost[]>(
       `${endpoint}${this.apiPath}posts${combinedArgs}`,
       {

--- a/node/utils/search.ts
+++ b/node/utils/search.ts
@@ -8,8 +8,7 @@ const postsWithTag = async (
     slug: search,
     customDomain,
   })
-
-  const total = tags.reduce((sum, tag) => sum + tag.count, 0)
+  const total = tags.length
 
   if (!total)
     return {
@@ -20,7 +19,7 @@ const postsWithTag = async (
     }
 
   const pages = Math.ceil(total / perPage)
-  const partialPage = perPage - (total % perPage)
+  const partialPage = perPage - (total % perPage) - 1
   const tagIds = tags.map(tag => tag.id)
 
   if (page > pages) {
@@ -36,6 +35,7 @@ const postsWithTag = async (
   const { data } = await wordpressProxy.getPosts({
     page,
     per_page: perPage,
+    search,
     tags: tagIds,
     customDomain,
   })


### PR DESCRIPTION
**How to test?**

Go to any category from the category links and go to articles, you will see the related posts using the category as terms.
If you want to see the exact terms used for you can open the console and search for `terms::`

[Workspace to test](https://usapps2--eriksbikeshop.myvtex.com/)