### PR TITLE
[WORDPRESS-46] turn off initialize site map setting when the account …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+-  Turn off initialize site map setting when the account has a secondary bindings.
+
 ## [2.18.0] - 2022-02-16
 
 ### Added

--- a/node/clients/sitemap.ts
+++ b/node/clients/sitemap.ts
@@ -31,6 +31,21 @@ export default class Sitemap extends AppGraphQLClient {
       return false
     }
 
+    if (settings.bindingBounded && settings.settings.length > 0) {
+      const hasInitMap = settings.settings.find(
+        (binding: any) => binding.initializeSitemap
+      )
+      if (hasInitMap) {
+        for (let i = 0; i < settings.settings.length; i++) {
+          const binding = settings.settings[i]
+          binding.initializeSitemap = false
+        }
+        await apps.saveAppSettings(appId, settings)
+
+        return false
+      }
+    }
+
     return true
   }
 


### PR DESCRIPTION
The current app was turning off the initialize site map setting for the main binding but...

When the account has some secondary bindings, it kept turn on those bindings and it was duplicating the entries.

[Slack conversation](https://vtex.slack.com/archives/C9P4RMW6Q/p1646761163952209?thread_ts=1645030592.653789&cid=C9P4RMW6Q)

