### PR TITLE
[WORDPRESS-57] Add date filter, Change category and tag filters, Fix pagination for search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix search result pagination to display new results after the second page instead of repeating same posts
+
+### Added
+
+- Add date filter in WordpressPosts
+- Change category and tag filter in WordpressPosts to send request to WordPress API to update pagination correctly
+
 ## [2.18.2] - 2022-04-01
 
 ### Fixed
@@ -16,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
--  Turn off initialize site map setting when the account has a secondary bindings.
+- Turn off initialize site map setting when the account has a secondary bindings.
 
 ## [2.18.0] - 2022-02-16
 
@@ -31,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix the documentation table about `mediaSize` props values and names.
 
 ## [2.17.0] - 2022-02-08
+
 ### Added
 
 - `showPostButton` prop to `blog-category-preview.wordpress-category-preview`, displays a button that allows the user to link directly to WP post

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -522,6 +522,7 @@ type Settings {
   displayShowRowsText: Boolean
   filterByCategories: Boolean
   filterByTags: Boolean
+  filterByDate: Boolean
 }
 
 type HeaderTags {
@@ -563,6 +564,10 @@ type Query {
     per_page: Int = 10
     search: String
     customDomain: String
+    before: String
+    after: String
+    categories: [Int]
+    tags: [Int]
   ): WPPostsResult @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
   wpPost(id: Int!, password: String, customDomain: String): WPPost
     @cacheControl(scope: PUBLIC, maxAge: MEDIUM)

--- a/manifest.json
+++ b/manifest.json
@@ -38,9 +38,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "settingsSchema": {
     "title": "Wordpress Integration",
@@ -89,6 +87,12 @@
       "filterByTags": {
         "title": "Filter by tags",
         "description": "Shows a dropdown containing all tags allowing you to filter your posts by the selected tag.",
+        "type": "boolean",
+        "default": false
+      },
+      "filterByDate": {
+        "title": "Filter by date",
+        "description": "Shows date fields to filter your posts by a single date or date range.",
         "type": "boolean",
         "default": false
       }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -106,6 +106,10 @@ export const queries = {
       per_page: number
       search?: string
       customDomain?: string
+      before?: string
+      after?: string
+      categories?: [number]
+      tags?: [number]
     },
     ctx: Context
   ): Promise<{ posts: WpPost[]; total_count: number }> => {

--- a/node/typings/appSettings.d.ts
+++ b/node/typings/appSettings.d.ts
@@ -8,6 +8,7 @@ interface Settings {
   initializeSitemap?: boolean
   filterByCategories?: boolean
   filterByTags?: boolean
+  filterByDate?: boolean
 }
 
 interface AppSettings extends Settings {

--- a/react/components/WordpressCategorySelect.tsx
+++ b/react/components/WordpressCategorySelect.tsx
@@ -6,12 +6,14 @@ interface WordpressCategorySelectProps {
   categories: any
   selectedCategory: any
   setSelectedCategory: any
+  setSelectedCategoryId: any
 }
 
 const WordpressCategorySelect: StorefrontFunctionComponent<WordpressCategorySelectProps> = ({
   categories,
   selectedCategory,
   setSelectedCategory,
+  setSelectedCategoryId,
 }) => {
   const intl = useIntl()
 
@@ -20,8 +22,13 @@ const WordpressCategorySelect: StorefrontFunctionComponent<WordpressCategorySele
       value: 'all',
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       label: intl.formatMessage(messages.allCategories),
+      id: undefined,
     },
-    ...categories.map((cat: any) => ({ value: cat.name, label: cat.name })),
+    ...categories.map((cat: any) => ({
+      value: cat.name,
+      label: cat.name,
+      id: cat.id,
+    })),
   ]
 
   return (
@@ -30,7 +37,13 @@ const WordpressCategorySelect: StorefrontFunctionComponent<WordpressCategorySele
       placeholder={intl.formatMessage(messages.filterByCategory)}
       options={categoryOptions}
       value={selectedCategory}
-      onChange={(_: any, v: any) => setSelectedCategory(v)}
+      onChange={(_: any, v: any) => {
+        setSelectedCategory(v)
+        const selectedOption = categoryOptions.find(
+          option => option.value === v
+        )
+        setSelectedCategoryId(selectedOption.id)
+      }}
     />
   )
 }

--- a/react/components/WordpressDateSelect.tsx
+++ b/react/components/WordpressDateSelect.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react'
+import { DatePicker, ButtonGroup, Button } from 'vtex.styleguide'
+import { useRuntime } from 'vtex.render-runtime'
+
+type DateType = Date | undefined
+interface WordpressDateSelectProps {
+  date: DateType
+  setDate: any
+  endDate: DateType
+  setEndDate: any
+  setDateFilter: any
+}
+
+const WordpressDateSelect: StorefrontFunctionComponent<WordpressDateSelectProps> = ({
+  date,
+  setDate,
+  endDate,
+  setEndDate,
+  setDateFilter,
+}) => {
+  const {
+    culture: { locale },
+  } = useRuntime()
+
+  const [tempStartDate, setTempStartDate] = useState<Date | undefined>(date)
+  const [tempEndDate, setTempEndDate] = useState<Date | undefined>(endDate)
+
+  return (
+    <div>
+      <div>
+        <DatePicker
+          locale={locale}
+          onChange={(newDate: Date) => {
+            setTempStartDate(newDate)
+            if (tempEndDate === undefined) {
+              setTempEndDate(newDate)
+            }
+          }}
+          value={tempStartDate}
+        />
+        <DatePicker
+          locale={locale}
+          onChange={(newDate: Date) => {
+            setTempEndDate(newDate)
+          }}
+          value={tempEndDate}
+          minDate={tempStartDate}
+        />
+        <ButtonGroup
+          buttons={[
+            <Button
+              variation="primary"
+              onClick={() => {
+                setDateFilter(true)
+
+                // flip dates if user enters start date later than end date
+                if (
+                  tempStartDate &&
+                  tempEndDate &&
+                  tempStartDate > tempEndDate
+                ) {
+                  setTempStartDate(tempEndDate)
+                  setTempEndDate(tempStartDate)
+                  setDate(tempEndDate)
+                  setEndDate(tempStartDate)
+                  return
+                }
+
+                setDate(tempStartDate)
+                setEndDate(tempEndDate)
+              }}
+            >
+              Apply
+            </Button>,
+            <Button
+              variation="secondary"
+              onClick={() => {
+                setDateFilter(false)
+
+                setTempStartDate(undefined)
+                setTempEndDate(undefined)
+                setDate(tempStartDate)
+                setEndDate(tempEndDate)
+              }}
+            >
+              Clear
+            </Button>,
+          ]}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default WordpressDateSelect

--- a/react/components/WordpressTagSelect.tsx
+++ b/react/components/WordpressTagSelect.tsx
@@ -6,12 +6,14 @@ interface WordpressTagSelectProps {
   tags: any
   selectedTag: any
   setSelectedTag: any
+  setSelectedTagId: any
 }
 
 const WordpressTagSelect: StorefrontFunctionComponent<WordpressTagSelectProps> = ({
   tags,
   selectedTag,
   setSelectedTag,
+  setSelectedTagId,
 }) => {
   const intl = useIntl()
   const tagOptions = [
@@ -19,8 +21,13 @@ const WordpressTagSelect: StorefrontFunctionComponent<WordpressTagSelectProps> =
       value: 'all',
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       label: intl.formatMessage(messages.allTags),
+      id: undefined,
     },
-    ...tags.map((tag: any) => ({ value: tag.name, label: tag.name })),
+    ...tags.map((tag: any) => ({
+      value: tag.name,
+      label: tag.name,
+      id: tag.id,
+    })),
   ]
 
   return (
@@ -29,7 +36,11 @@ const WordpressTagSelect: StorefrontFunctionComponent<WordpressTagSelectProps> =
       placeholder={intl.formatMessage(messages.filterByTag)}
       options={tagOptions}
       value={selectedTag}
-      onChange={(_: any, l: any) => setSelectedTag(l)}
+      onChange={(_: any, l: any) => {
+        setSelectedTag(l)
+        const selectedOption = tagOptions.find(option => option.value === l)
+        setSelectedTagId(selectedOption.id)
+      }}
     />
   )
 }

--- a/react/graphql/AllPosts.graphql
+++ b/react/graphql/AllPosts.graphql
@@ -5,6 +5,9 @@ query AllPosts(
   $tags_exclude: [Int]
   $categories_exclude: [Int]
   $customDomain: String
+  $before: String
+  $after: String
+  $categories: [Int]
 ) {
   wpPosts(
     page: $wp_page
@@ -13,6 +16,9 @@ query AllPosts(
     tags_exclude: $tags_exclude
     categories_exclude: $categories_exclude
     customDomain: $customDomain
+    before: $before
+    after: $after
+    categories: $categories
   ) {
     posts {
       title {

--- a/react/graphql/SearchPosts.graphql
+++ b/react/graphql/SearchPosts.graphql
@@ -3,12 +3,20 @@ query SearchPosts(
   $wp_per_page: Int
   $terms: String
   $customDomain: String
+  $before: String
+  $after: String
+  $categories: [Int]
+  $tags: [Int]
 ) {
   wpPostsSearch(
     page: $wp_page
     per_page: $wp_per_page
     search: $terms
     customDomain: $customDomain
+    before: $before
+    after: $after
+    categories: $categories
+    tags: $tags
   ) {
     posts {
       title {

--- a/react/graphql/Settings.graphql
+++ b/react/graphql/Settings.graphql
@@ -4,5 +4,6 @@ query Settings {
     displayShowRowsText
     filterByCategories
     filterByTags
+    filterByDate
   }
 }

--- a/react/utils/getNextDay.ts
+++ b/react/utils/getNextDay.ts
@@ -1,0 +1,9 @@
+const getNextDay = (date: Date | undefined) => {
+  if (date === undefined) return undefined
+
+  const nextDay = new Date(date)
+  nextDay.setDate(nextDay.getDate() + 1)
+  return nextDay
+}
+
+export default getNextDay


### PR DESCRIPTION
**What problem is this solving?**

- Add date filter
- Change category and tag filters to make request to WordPress API instead of filtering results after getting posts. This is to keep pagination up to date according to filtered results.
- Fix bug in search results pagination where the second page onwards displayed the same posts.

**How should this be manually tested?**

Here's a workspace ([annawordpress](https://annawordpress--rmoils.myvtex.com/learn)) where this can be tested. Otherwise, link these changes to a workspace, enable the filtering options in app settings, and start filtering posts by category, tag, and/or date. Do the same after searching for blog posts with a search term.