### PR TITLE
[WORDPRESS-58] Get the correct sitemap urls for blog-posts and categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Get the urlBase depending on the rooth path when multiple bindings on blog-posts and blog-categories sitemap entries.
+
 ## [2.19.1] - 2022-05-26
 
 ### Fixed


### PR DESCRIPTION
**What problem is this solving?**

The problem is in the Wordpress app. For example:
https://www.ametllerorigen.com/es/sitemap/blog-categories.xml
https://www.ametllerorigen.com/ca/sitemap/blog-categories.xml
Both of these have lists of /ca/ URLs, so we need to figure out why the app is not returning /es/ URLs when that binding is in use

**How should this be manually tested?**
If you go to this urls you should see urls with `ca` or `es` respectively.
https://www.ametllerorigen.com/ca/sitemap/blog-posts.xml?workspace=fixsitemap
https://www.ametllerorigen.com/es/sitemap/blog-posts.xml?workspace=fixsitemap

**Screenshots or example usage:**